### PR TITLE
fix: ArgoCD namespace configurable for OpenShift GitOps (#34)

### DIFF
--- a/internal/generator/docs.go
+++ b/internal/generator/docs.go
@@ -51,11 +51,13 @@ func (g *Generator) generateDocs() error {
 func (g *Generator) generateBootstrap() error {
 	fmt.Println("🔧 Generating bootstrap...")
 
+	argoCDNamespace := g.getArgoCDNamespace()
+
 	bootstrapContent := fmt.Sprintf(`apiVersion: v1
 kind: Namespace
 metadata:
   name: %s
-`, g.Config.GitOpsTool)
+`, argoCDNamespace)
 
 	path := fmt.Sprintf("%s/bootstrap/%s/namespace.yaml",
 		g.Config.Project.Name, g.Config.GitOpsTool)

--- a/internal/templates/files/argocd/application.yaml.tmpl
+++ b/internal/templates/files/argocd/application.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{.Name}}
-  namespace: argocd
+  namespace: {{.ArgoCDNamespace}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/internal/templates/files/argocd/project.yaml.tmpl
+++ b/internal/templates/files/argocd/project.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: {{.Name}}
-  namespace: argocd
+  namespace: {{.ArgoCDNamespace}}
 spec:
   description: {{if .Description}}{{.Description}}{{else}}Project for {{.Name}}{{end}}
   sourceRepos:


### PR DESCRIPTION
## Summary
Fixes the bug where generated ArgoCD manifests used hardcoded `argocd` namespace, causing validation failures on OpenShift GitOps clusters.

## Changes
- Add `getArgoCDNamespace()` helper function in generator
- Auto-detect platform and set appropriate namespace:
  - **OpenShift**: `openshift-gitops`
  - **Kubernetes/AKS/EKS**: `argocd`
- Allow explicit override via `bootstrap.namespace` config
- Update templates to use `{{ .ArgoCDNamespace }}` instead of hardcoded value

## Files Changed
- `internal/generator/argocd.go` - Add namespace detection logic
- `internal/generator/docs.go` - Use dynamic namespace in bootstrap
- `internal/templates/files/argocd/project.yaml.tmpl` - Dynamic namespace
- `internal/templates/files/argocd/application.yaml.tmpl` - Dynamic namespace
- `internal/generator/generator_test.go` - Add tests for OpenShift and custom namespace

## Testing
- ✅ All unit tests pass
- ✅ E2E test on OpenShift validates manifests successfully
- ✅ Generated manifests use `openshift-gitops` namespace for OpenShift platform

## E2E Validation Results
```
✅ VALID: argocd/projects/infrastructure.yaml
✅ VALID: argocd/projects/applications.yaml
✅ VALID: argocd/applicationsets/apps-dev.yaml
✅ VALID: argocd/applicationsets/infra-dev.yaml
...
```

Fixes #34