### PR TITLE
feat(bootstrap): Auto-apply generated ArgoCD manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ docs-internal/
 CLAUDE.md
 claude.md
 gitopsi-darwin
+gitopsi-linux

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,7 +188,7 @@ func NewDefaultConfig() *Config {
 			Enabled:         false,
 			Tool:            "argocd",
 			Mode:            "helm",
-			Namespace:       "argocd",
+			Namespace:       "", // Empty to allow platform-based detection (openshift-gitops vs argocd)
 			Wait:            true,
 			Timeout:         300,
 			ConfigureRepo:   true,

--- a/internal/generator/argocd.go
+++ b/internal/generator/argocd.go
@@ -82,6 +82,9 @@ func (g *Generator) generateArgoCDProjects(argoCDNamespace string) error {
 func (g *Generator) generateSingleClusterArgoCD(argoCDNamespace string) error {
 	repoURL := g.Config.Output.URL
 	if repoURL == "" {
+		repoURL = g.Config.Git.URL
+	}
+	if repoURL == "" {
 		repoURL = "https://github.com/org/" + g.Config.Project.Name + ".git"
 	}
 
@@ -136,6 +139,9 @@ func (g *Generator) generateSingleClusterArgoCD(argoCDNamespace string) error {
 
 func (g *Generator) generateMultiClusterArgoCD(argoCDNamespace string) error {
 	repoURL := g.Config.Output.URL
+	if repoURL == "" {
+		repoURL = g.Config.Git.URL
+	}
 	if repoURL == "" {
 		repoURL = "https://github.com/org/" + g.Config.Project.Name + ".git"
 	}


### PR DESCRIPTION
## Summary
Implements Issue #41 - Enhance bootstrap to auto-apply generated ArgoCD manifests.

## Changes
### Bootstrap Module (`internal/bootstrap/bootstrap.go`)
- **BootstrapOrDetect**: Detects existing ArgoCD installation or installs new
- **ApplyGeneratedManifests**: Applies ArgoCD projects, applications, and applicationsets
- **WaitForAppSync**: Monitors application sync status with timeout
- **GetApplicationStatus**: Real-time application status queries
- **SyncStatus struct**: Track sync state of applications

### Init Command (`internal/cli/init.go`)
- Integrated new bootstrap flow with detection and auto-apply
- Added progress tracking for each step
- Display sync status after bootstrap

### Config (`internal/config/config.go`)
- **BUGFIX**: Changed `Bootstrap.Namespace` default from `argocd` to empty string
- This allows platform-based namespace detection (`openshift-gitops` for OpenShift)

### ArgoCD Generator (`internal/generator/argocd.go`)
- **BUGFIX**: Fall back to `Git.URL` if `Output.URL` is not set
- Fixes issue where ArgoCD applications had incorrect `repoURL`

## E2E Test Results
Full end-to-end test on OpenShift cluster:
- ✅ Both applications synced successfully
- ✅ Nginx pods running (2 replicas)
- ✅ Namespace created via ArgoCD auto-sync
- ✅ Platform-specific namespace (`openshift-gitops`) used correctly

```
NAME                         SYNC     HEALTH    REPO
gitopsi-e2e-test-apps-dev    Synced   Healthy   https://github.com/ihsanmokhlisse/gitopsitest
gitopsi-e2e-test-infra-dev   Synced   Healthy   https://github.com/ihsanmokhlisse/gitopsitest
```

## How to Test
```bash
# Generate and bootstrap
gitopsi init --config config.yaml --cluster <url> --bootstrap

# The tool will:
# 1. Detect existing ArgoCD or install new
# 2. Apply generated ArgoCD projects
# 3. Apply generated ArgoCD applications
# 4. Wait for sync completion
# 5. Display final status
```

Closes #41