### PR TITLE
feat(config): add preset configurations and customizable generation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,21 @@
 package config
 
+// Preset defines a configuration preset type
+type Preset string
+
+const (
+	PresetMinimal    Preset = "minimal"
+	PresetStandard   Preset = "standard"
+	PresetEnterprise Preset = "enterprise"
+	PresetCustom     Preset = "custom"
+)
+
 // Config represents the complete gitopsi configuration.
 type Config struct {
+	Preset       Preset              `yaml:"preset,omitempty"`
 	Project      Project             `yaml:"project"`
+	Structure    StructureConfig     `yaml:"structure,omitempty"`
+	Generate     GenerateConfig      `yaml:"generate,omitempty"`
 	Output       Output              `yaml:"output"`
 	Git          GitConfig           `yaml:"git"`
 	Cluster      ClusterConfig       `yaml:"cluster"`
@@ -15,6 +28,76 @@ type Config struct {
 	Infra        Infrastructure      `yaml:"infrastructure"`
 	Apps         []Application       `yaml:"applications"`
 	Docs         Documentation       `yaml:"docs"`
+}
+
+// StructureConfig defines custom directory structure
+type StructureConfig struct {
+	InfrastructureDir string      `yaml:"infrastructure_dir,omitempty"`
+	ApplicationsDir   string      `yaml:"applications_dir,omitempty"`
+	BootstrapDir      string      `yaml:"bootstrap_dir,omitempty"`
+	ScriptsDir        string      `yaml:"scripts_dir,omitempty"`
+	DocsDir           string      `yaml:"docs_dir,omitempty"`
+	CustomDirs        []CustomDir `yaml:"custom_dirs,omitempty"`
+}
+
+// CustomDir defines a custom directory to create
+type CustomDir struct {
+	Path        string `yaml:"path"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// GenerateConfig defines what components to generate
+type GenerateConfig struct {
+	Infrastructure GenerateInfra   `yaml:"infrastructure,omitempty"`
+	Applications   GenerateApps    `yaml:"applications,omitempty"`
+	GitOps         GenerateGitOps  `yaml:"gitops,omitempty"`
+	Docs           GenerateDocs    `yaml:"docs,omitempty"`
+	Scripts        GenerateScripts `yaml:"scripts,omitempty"`
+}
+
+// GenerateInfra defines infrastructure generation options
+type GenerateInfra struct {
+	Namespaces      *bool `yaml:"namespaces,omitempty"`
+	RBAC            *bool `yaml:"rbac,omitempty"`
+	NetworkPolicies *bool `yaml:"network_policies,omitempty"`
+	ResourceQuotas  *bool `yaml:"resource_quotas,omitempty"`
+	LimitRanges     *bool `yaml:"limit_ranges,omitempty"`
+	ServiceAccounts *bool `yaml:"service_accounts,omitempty"`
+}
+
+// GenerateApps defines application generation options
+type GenerateApps struct {
+	Deployments     *bool `yaml:"deployments,omitempty"`
+	Services        *bool `yaml:"services,omitempty"`
+	Ingress         *bool `yaml:"ingress,omitempty"`
+	HPA             *bool `yaml:"hpa,omitempty"`
+	PDB             *bool `yaml:"pdb,omitempty"`
+	ServiceAccounts *bool `yaml:"service_accounts,omitempty"`
+}
+
+// GenerateGitOps defines GitOps resource generation options
+type GenerateGitOps struct {
+	Projects        *bool `yaml:"projects,omitempty"`
+	Applications    *bool `yaml:"applications,omitempty"`
+	ApplicationSets *bool `yaml:"applicationsets,omitempty"`
+	AppOfApps       *bool `yaml:"app_of_apps,omitempty"`
+}
+
+// GenerateDocs defines documentation generation options
+type GenerateDocs struct {
+	Readme       *bool `yaml:"readme,omitempty"`
+	Architecture *bool `yaml:"architecture,omitempty"`
+	Onboarding   *bool `yaml:"onboarding,omitempty"`
+	Runbook      *bool `yaml:"runbook,omitempty"`
+	ADR          *bool `yaml:"adr,omitempty"`
+}
+
+// GenerateScripts defines script generation options
+type GenerateScripts struct {
+	Bootstrap *bool `yaml:"bootstrap,omitempty"`
+	Validate  *bool `yaml:"validate,omitempty"`
+	Sync      *bool `yaml:"sync,omitempty"`
+	Rollback  *bool `yaml:"rollback,omitempty"`
 }
 
 type Project struct {
@@ -245,4 +328,192 @@ func (c *Config) GetEnvironmentClusters(envName string) []EnvironmentCluster {
 
 func (c *Config) IsMultiCluster() bool {
 	return c.Topology == TopologyClusterPerEnv || c.Topology == TopologyMultiCluster
+}
+
+// ApplyPreset applies a preset configuration
+func (c *Config) ApplyPreset() {
+	switch c.Preset {
+	case PresetMinimal:
+		c.applyMinimalPreset()
+	case PresetStandard:
+		c.applyStandardPreset()
+	case PresetEnterprise:
+		c.applyEnterprisePreset()
+	}
+}
+
+func (c *Config) applyMinimalPreset() {
+	c.Infra = Infrastructure{
+		Namespaces:      true,
+		RBAC:            false,
+		NetworkPolicies: false,
+		ResourceQuotas:  false,
+	}
+	c.Docs = Documentation{
+		Readme:       true,
+		Architecture: false,
+		Onboarding:   false,
+	}
+	if len(c.Environments) == 0 {
+		c.Environments = []Environment{{Name: "dev"}}
+	}
+}
+
+func (c *Config) applyStandardPreset() {
+	c.Infra = Infrastructure{
+		Namespaces:      true,
+		RBAC:            true,
+		NetworkPolicies: true,
+		ResourceQuotas:  true,
+	}
+	c.Docs = Documentation{
+		Readme:       true,
+		Architecture: true,
+		Onboarding:   true,
+	}
+	if len(c.Environments) == 0 {
+		c.Environments = []Environment{
+			{Name: "dev"},
+			{Name: "staging"},
+			{Name: "prod"},
+		}
+	}
+}
+
+func (c *Config) applyEnterprisePreset() {
+	c.Infra = Infrastructure{
+		Namespaces:      true,
+		RBAC:            true,
+		NetworkPolicies: true,
+		ResourceQuotas:  true,
+	}
+	c.Docs = Documentation{
+		Readme:       true,
+		Architecture: true,
+		Onboarding:   true,
+	}
+	// Enterprise adds custom directories for monitoring and policies
+	c.Structure.CustomDirs = append(c.Structure.CustomDirs,
+		CustomDir{Path: "monitoring/dashboards", Description: "Grafana dashboards"},
+		CustomDir{Path: "monitoring/alerts", Description: "Alertmanager rules"},
+		CustomDir{Path: "policies/opa", Description: "OPA/Gatekeeper policies"},
+	)
+	if len(c.Environments) == 0 {
+		c.Environments = []Environment{
+			{Name: "dev"},
+			{Name: "staging"},
+			{Name: "prod"},
+		}
+	}
+}
+
+// GetInfrastructureDir returns the infrastructure directory name
+func (c *Config) GetInfrastructureDir() string {
+	if c.Structure.InfrastructureDir != "" {
+		return c.Structure.InfrastructureDir
+	}
+	return "infrastructure"
+}
+
+// GetApplicationsDir returns the applications directory name
+func (c *Config) GetApplicationsDir() string {
+	if c.Structure.ApplicationsDir != "" {
+		return c.Structure.ApplicationsDir
+	}
+	return "applications"
+}
+
+// GetBootstrapDir returns the bootstrap directory name
+func (c *Config) GetBootstrapDir() string {
+	if c.Structure.BootstrapDir != "" {
+		return c.Structure.BootstrapDir
+	}
+	return "bootstrap"
+}
+
+// GetScriptsDir returns the scripts directory name
+func (c *Config) GetScriptsDir() string {
+	if c.Structure.ScriptsDir != "" {
+		return c.Structure.ScriptsDir
+	}
+	return "scripts"
+}
+
+// GetDocsDir returns the docs directory name
+func (c *Config) GetDocsDir() string {
+	if c.Structure.DocsDir != "" {
+		return c.Structure.DocsDir
+	}
+	return "docs"
+}
+
+// ShouldGenerateNamespaces returns whether to generate namespaces
+func (c *Config) ShouldGenerateNamespaces() bool {
+	if c.Generate.Infrastructure.Namespaces != nil {
+		return *c.Generate.Infrastructure.Namespaces
+	}
+	return c.Infra.Namespaces
+}
+
+// ShouldGenerateRBAC returns whether to generate RBAC
+func (c *Config) ShouldGenerateRBAC() bool {
+	if c.Generate.Infrastructure.RBAC != nil {
+		return *c.Generate.Infrastructure.RBAC
+	}
+	return c.Infra.RBAC
+}
+
+// ShouldGenerateNetworkPolicies returns whether to generate network policies
+func (c *Config) ShouldGenerateNetworkPolicies() bool {
+	if c.Generate.Infrastructure.NetworkPolicies != nil {
+		return *c.Generate.Infrastructure.NetworkPolicies
+	}
+	return c.Infra.NetworkPolicies
+}
+
+// ShouldGenerateResourceQuotas returns whether to generate resource quotas
+func (c *Config) ShouldGenerateResourceQuotas() bool {
+	if c.Generate.Infrastructure.ResourceQuotas != nil {
+		return *c.Generate.Infrastructure.ResourceQuotas
+	}
+	return c.Infra.ResourceQuotas
+}
+
+// ShouldGenerateReadme returns whether to generate README
+func (c *Config) ShouldGenerateReadme() bool {
+	if c.Generate.Docs.Readme != nil {
+		return *c.Generate.Docs.Readme
+	}
+	return c.Docs.Readme
+}
+
+// ShouldGenerateArchitecture returns whether to generate architecture docs
+func (c *Config) ShouldGenerateArchitecture() bool {
+	if c.Generate.Docs.Architecture != nil {
+		return *c.Generate.Docs.Architecture
+	}
+	return c.Docs.Architecture
+}
+
+// ShouldGenerateOnboarding returns whether to generate onboarding docs
+func (c *Config) ShouldGenerateOnboarding() bool {
+	if c.Generate.Docs.Onboarding != nil {
+		return *c.Generate.Docs.Onboarding
+	}
+	return c.Docs.Onboarding
+}
+
+// ValidPresets returns list of valid preset names
+func ValidPresets() []string {
+	return []string{string(PresetMinimal), string(PresetStandard), string(PresetEnterprise), string(PresetCustom)}
+}
+
+// IsValidPreset checks if a preset name is valid
+func IsValidPreset(preset string) bool {
+	for _, p := range ValidPresets() {
+		if p == preset {
+			return true
+		}
+	}
+	return preset == ""
 }

--- a/internal/config/preset_test.go
+++ b/internal/config/preset_test.go
@@ -1,0 +1,229 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPresetConstants(t *testing.T) {
+	assert.Equal(t, Preset("minimal"), PresetMinimal)
+	assert.Equal(t, Preset("standard"), PresetStandard)
+	assert.Equal(t, Preset("enterprise"), PresetEnterprise)
+	assert.Equal(t, Preset("custom"), PresetCustom)
+}
+
+func TestValidPresets(t *testing.T) {
+	presets := ValidPresets()
+	assert.Contains(t, presets, "minimal")
+	assert.Contains(t, presets, "standard")
+	assert.Contains(t, presets, "enterprise")
+	assert.Contains(t, presets, "custom")
+	assert.Len(t, presets, 4)
+}
+
+func TestIsValidPreset(t *testing.T) {
+	assert.True(t, IsValidPreset("minimal"))
+	assert.True(t, IsValidPreset("standard"))
+	assert.True(t, IsValidPreset("enterprise"))
+	assert.True(t, IsValidPreset("custom"))
+	assert.True(t, IsValidPreset(""))
+	assert.False(t, IsValidPreset("invalid"))
+	assert.False(t, IsValidPreset("MINIMAL"))
+}
+
+func TestApplyMinimalPreset(t *testing.T) {
+	cfg := &Config{
+		Preset:  PresetMinimal,
+		Project: Project{Name: "test"},
+	}
+
+	cfg.ApplyPreset()
+
+	assert.True(t, cfg.Infra.Namespaces)
+	assert.False(t, cfg.Infra.RBAC)
+	assert.False(t, cfg.Infra.NetworkPolicies)
+	assert.False(t, cfg.Infra.ResourceQuotas)
+	assert.True(t, cfg.Docs.Readme)
+	assert.False(t, cfg.Docs.Architecture)
+	assert.False(t, cfg.Docs.Onboarding)
+	assert.Len(t, cfg.Environments, 1)
+	assert.Equal(t, "dev", cfg.Environments[0].Name)
+}
+
+func TestApplyStandardPreset(t *testing.T) {
+	cfg := &Config{
+		Preset:  PresetStandard,
+		Project: Project{Name: "test"},
+	}
+
+	cfg.ApplyPreset()
+
+	assert.True(t, cfg.Infra.Namespaces)
+	assert.True(t, cfg.Infra.RBAC)
+	assert.True(t, cfg.Infra.NetworkPolicies)
+	assert.True(t, cfg.Infra.ResourceQuotas)
+	assert.True(t, cfg.Docs.Readme)
+	assert.True(t, cfg.Docs.Architecture)
+	assert.True(t, cfg.Docs.Onboarding)
+	assert.Len(t, cfg.Environments, 3)
+}
+
+func TestApplyEnterprisePreset(t *testing.T) {
+	cfg := &Config{
+		Preset:  PresetEnterprise,
+		Project: Project{Name: "test"},
+	}
+
+	cfg.ApplyPreset()
+
+	assert.True(t, cfg.Infra.Namespaces)
+	assert.True(t, cfg.Infra.RBAC)
+	assert.True(t, cfg.Infra.NetworkPolicies)
+	assert.True(t, cfg.Infra.ResourceQuotas)
+	assert.True(t, cfg.Docs.Readme)
+	assert.True(t, cfg.Docs.Architecture)
+	assert.True(t, cfg.Docs.Onboarding)
+	assert.GreaterOrEqual(t, len(cfg.Structure.CustomDirs), 3)
+	assert.Len(t, cfg.Environments, 3)
+}
+
+func TestPresetPreservesExistingEnvironments(t *testing.T) {
+	cfg := &Config{
+		Preset:  PresetMinimal,
+		Project: Project{Name: "test"},
+		Environments: []Environment{
+			{Name: "custom-env"},
+		},
+	}
+
+	cfg.ApplyPreset()
+
+	assert.Len(t, cfg.Environments, 1)
+	assert.Equal(t, "custom-env", cfg.Environments[0].Name)
+}
+
+func TestGetInfrastructureDir(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "infrastructure", cfg.GetInfrastructureDir())
+
+	cfg.Structure.InfrastructureDir = "infra"
+	assert.Equal(t, "infra", cfg.GetInfrastructureDir())
+}
+
+func TestGetApplicationsDir(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "applications", cfg.GetApplicationsDir())
+
+	cfg.Structure.ApplicationsDir = "apps"
+	assert.Equal(t, "apps", cfg.GetApplicationsDir())
+}
+
+func TestGetBootstrapDir(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "bootstrap", cfg.GetBootstrapDir())
+
+	cfg.Structure.BootstrapDir = "setup"
+	assert.Equal(t, "setup", cfg.GetBootstrapDir())
+}
+
+func TestGetScriptsDir(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "scripts", cfg.GetScriptsDir())
+
+	cfg.Structure.ScriptsDir = "bin"
+	assert.Equal(t, "bin", cfg.GetScriptsDir())
+}
+
+func TestGetDocsDir(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "docs", cfg.GetDocsDir())
+
+	cfg.Structure.DocsDir = "documentation"
+	assert.Equal(t, "documentation", cfg.GetDocsDir())
+}
+
+func TestShouldGenerateNamespaces(t *testing.T) {
+	cfg := &Config{Infra: Infrastructure{Namespaces: true}}
+	assert.True(t, cfg.ShouldGenerateNamespaces())
+
+	cfg.Infra.Namespaces = false
+	assert.False(t, cfg.ShouldGenerateNamespaces())
+
+	// Override via Generate
+	val := true
+	cfg.Generate.Infrastructure.Namespaces = &val
+	assert.True(t, cfg.ShouldGenerateNamespaces())
+}
+
+func TestShouldGenerateRBAC(t *testing.T) {
+	cfg := &Config{Infra: Infrastructure{RBAC: true}}
+	assert.True(t, cfg.ShouldGenerateRBAC())
+
+	cfg.Infra.RBAC = false
+	assert.False(t, cfg.ShouldGenerateRBAC())
+
+	val := true
+	cfg.Generate.Infrastructure.RBAC = &val
+	assert.True(t, cfg.ShouldGenerateRBAC())
+}
+
+func TestShouldGenerateNetworkPolicies(t *testing.T) {
+	cfg := &Config{Infra: Infrastructure{NetworkPolicies: true}}
+	assert.True(t, cfg.ShouldGenerateNetworkPolicies())
+
+	cfg.Infra.NetworkPolicies = false
+	assert.False(t, cfg.ShouldGenerateNetworkPolicies())
+
+	val := true
+	cfg.Generate.Infrastructure.NetworkPolicies = &val
+	assert.True(t, cfg.ShouldGenerateNetworkPolicies())
+}
+
+func TestShouldGenerateResourceQuotas(t *testing.T) {
+	cfg := &Config{Infra: Infrastructure{ResourceQuotas: true}}
+	assert.True(t, cfg.ShouldGenerateResourceQuotas())
+
+	cfg.Infra.ResourceQuotas = false
+	assert.False(t, cfg.ShouldGenerateResourceQuotas())
+
+	val := true
+	cfg.Generate.Infrastructure.ResourceQuotas = &val
+	assert.True(t, cfg.ShouldGenerateResourceQuotas())
+}
+
+func TestShouldGenerateDocs(t *testing.T) {
+	cfg := &Config{Docs: Documentation{Readme: true, Architecture: true, Onboarding: true}}
+	assert.True(t, cfg.ShouldGenerateReadme())
+	assert.True(t, cfg.ShouldGenerateArchitecture())
+	assert.True(t, cfg.ShouldGenerateOnboarding())
+
+	cfg.Docs = Documentation{Readme: false, Architecture: false, Onboarding: false}
+	assert.False(t, cfg.ShouldGenerateReadme())
+	assert.False(t, cfg.ShouldGenerateArchitecture())
+	assert.False(t, cfg.ShouldGenerateOnboarding())
+
+	// Override via Generate
+	val := true
+	cfg.Generate.Docs.Readme = &val
+	cfg.Generate.Docs.Architecture = &val
+	cfg.Generate.Docs.Onboarding = &val
+	assert.True(t, cfg.ShouldGenerateReadme())
+	assert.True(t, cfg.ShouldGenerateArchitecture())
+	assert.True(t, cfg.ShouldGenerateOnboarding())
+}
+
+func TestCustomDirs(t *testing.T) {
+	cfg := &Config{
+		Structure: StructureConfig{
+			CustomDirs: []CustomDir{
+				{Path: "monitoring/dashboards", Description: "Grafana dashboards"},
+				{Path: "policies/opa", Description: "OPA policies"},
+			},
+		},
+	}
+
+	assert.Len(t, cfg.Structure.CustomDirs, 2)
+	assert.Equal(t, "monitoring/dashboards", cfg.Structure.CustomDirs[0].Path)
+	assert.Equal(t, "Grafana dashboards", cfg.Structure.CustomDirs[0].Description)
+}


### PR DESCRIPTION
## Summary
Adds comprehensive preset configuration system allowing users to quickly set up GitOps repositories with predefined configurations.

## Presets

| Preset | Description | Components |
|--------|-------------|------------|
| `minimal` | Quick start | Namespaces, README, single env |
| `standard` | Default | Full infra + apps + docs |
| `enterprise` | Full-featured | Everything + monitoring + policies dirs |

## Usage

```bash
# Use preset from CLI
gitopsi init --preset minimal
gitopsi init --preset enterprise

# Use preset from config file
preset: minimal
project:
  name: my-app
```

## Custom Directory Structure

```yaml
structure:
  infrastructure_dir: infra
  applications_dir: apps
  bootstrap_dir: setup
  scripts_dir: bin
  docs_dir: documentation
  custom_dirs:
    - path: monitoring/dashboards
    - path: policies/opa
```

## Selective Generation

```yaml
generate:
  infrastructure:
    namespaces: true
    rbac: true
    network_policies: false
  docs:
    readme: true
    architecture: false
```

## Testing
- Added 18 unit tests for preset functionality
- All existing tests pass

Fixes #18