### PR TITLE
feat(operator): add Kubernetes Operator management

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -1,0 +1,385 @@
+// Package operator provides Kubernetes Operator management for GitOps.
+package operator
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Operator represents a Kubernetes Operator configuration.
+type Operator struct {
+	// Name is the operator name (e.g., "prometheus-operator")
+	Name string `yaml:"name" json:"name"`
+	// Namespace where the operator will be installed
+	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	// Channel is the OLM channel to subscribe to
+	Channel string `yaml:"channel,omitempty" json:"channel,omitempty"`
+	// Source is the CatalogSource (e.g., "community-operators", "redhat-operators")
+	Source string `yaml:"source,omitempty" json:"source,omitempty"`
+	// SourceNamespace is the namespace of the CatalogSource
+	SourceNamespace string `yaml:"source_namespace,omitempty" json:"source_namespace,omitempty"`
+	// Version specifies a specific version to install
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	// InstallPlanApproval is Automatic or Manual
+	InstallPlanApproval string `yaml:"install_plan_approval,omitempty" json:"install_plan_approval,omitempty"`
+	// Config allows passing custom configuration
+	Config map[string]any `yaml:"config,omitempty" json:"config,omitempty"`
+	// Enabled controls whether this operator should be deployed
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// TargetNamespaces for AllNamespaces/OwnNamespace/SingleNamespace/MultiNamespace install modes
+	TargetNamespaces []string `yaml:"target_namespaces,omitempty" json:"target_namespaces,omitempty"`
+	// InstallMode is the OLM install mode
+	InstallMode string `yaml:"install_mode,omitempty" json:"install_mode,omitempty"`
+}
+
+// InstallMode represents OLM operator install modes.
+type InstallMode string
+
+const (
+	InstallModeOwnNamespace    InstallMode = "OwnNamespace"
+	InstallModeSingleNamespace InstallMode = "SingleNamespace"
+	InstallModeMultiNamespace  InstallMode = "MultiNamespace"
+	InstallModeAllNamespaces   InstallMode = "AllNamespaces"
+)
+
+// CatalogSource represents an OLM CatalogSource.
+type CatalogSource string
+
+const (
+	CatalogSourceCommunity   CatalogSource = "community-operators"
+	CatalogSourceRedHat      CatalogSource = "redhat-operators"
+	CatalogSourceCertified   CatalogSource = "certified-operators"
+	CatalogSourceMarketplace CatalogSource = "redhat-marketplace"
+	CatalogSourceOperatorHub CatalogSource = "operatorhubio-catalog"
+)
+
+// CommonOperators provides presets for commonly used operators.
+var CommonOperators = map[string]Operator{
+	"prometheus": {
+		Name:            "prometheus-operator",
+		Channel:         "beta",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "openshift-monitoring",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"grafana": {
+		Name:            "grafana-operator",
+		Channel:         "v5",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "grafana",
+		InstallMode:     string(InstallModeOwnNamespace),
+		Enabled:         true,
+	},
+	"cert-manager": {
+		Name:            "cert-manager",
+		Channel:         "stable",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "cert-manager",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"external-secrets": {
+		Name:            "external-secrets-operator",
+		Channel:         "stable",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "external-secrets",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"sealed-secrets": {
+		Name:            "sealed-secrets-operator-helm",
+		Channel:         "alpha",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "sealed-secrets",
+		InstallMode:     string(InstallModeOwnNamespace),
+		Enabled:         true,
+	},
+	"kyverno": {
+		Name:            "kyverno-operator",
+		Channel:         "stable",
+		Source:          string(CatalogSourceCommunity),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "kyverno",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"opa-gatekeeper": {
+		Name:            "gatekeeper-operator-product",
+		Channel:         "stable",
+		Source:          string(CatalogSourceRedHat),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "gatekeeper-system",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"elasticsearch": {
+		Name:            "elasticsearch-operator",
+		Channel:         "stable-5.8",
+		Source:          string(CatalogSourceRedHat),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "openshift-operators-redhat",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"jaeger": {
+		Name:            "jaeger-product",
+		Channel:         "stable",
+		Source:          string(CatalogSourceRedHat),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "openshift-distributed-tracing",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+	"servicemesh": {
+		Name:            "servicemeshoperator",
+		Channel:         "stable",
+		Source:          string(CatalogSourceRedHat),
+		SourceNamespace: "openshift-marketplace",
+		Namespace:       "openshift-operators",
+		InstallMode:     string(InstallModeAllNamespaces),
+		Enabled:         true,
+	},
+}
+
+// GetOperatorPreset returns a preset operator configuration by name.
+func GetOperatorPreset(name string) (*Operator, bool) {
+	op, ok := CommonOperators[strings.ToLower(name)]
+	if ok {
+		return &op, true
+	}
+	return nil, false
+}
+
+// ListOperatorPresets returns all available operator presets.
+func ListOperatorPresets() []string {
+	names := make([]string, 0, len(CommonOperators))
+	for name := range CommonOperators {
+		names = append(names, name)
+	}
+	return names
+}
+
+// Config holds the operator management configuration.
+type Config struct {
+	// Enabled controls whether operator management is enabled
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Operators is the list of operators to manage
+	Operators []Operator `yaml:"operators,omitempty" json:"operators,omitempty"`
+	// CreateOperatorGroup controls whether to create OperatorGroups
+	CreateOperatorGroup bool `yaml:"create_operator_group" json:"create_operator_group"`
+	// DefaultSource is the default CatalogSource
+	DefaultSource string `yaml:"default_source,omitempty" json:"default_source,omitempty"`
+	// DefaultSourceNamespace is the default CatalogSource namespace
+	DefaultSourceNamespace string `yaml:"default_source_namespace,omitempty" json:"default_source_namespace,omitempty"`
+}
+
+// NewDefaultConfig creates a default operator configuration.
+func NewDefaultConfig() Config {
+	return Config{
+		Enabled:                false,
+		Operators:              []Operator{},
+		CreateOperatorGroup:    true,
+		DefaultSource:          string(CatalogSourceCommunity),
+		DefaultSourceNamespace: "openshift-marketplace",
+	}
+}
+
+// Validate validates the operator configuration.
+func (o *Operator) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("operator name is required")
+	}
+	if o.Namespace == "" {
+		return fmt.Errorf("operator namespace is required for %s", o.Name)
+	}
+	if o.InstallMode != "" {
+		validModes := []string{
+			string(InstallModeOwnNamespace),
+			string(InstallModeSingleNamespace),
+			string(InstallModeMultiNamespace),
+			string(InstallModeAllNamespaces),
+		}
+		valid := false
+		for _, m := range validModes {
+			if o.InstallMode == m {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("invalid install mode: %s", o.InstallMode)
+		}
+	}
+	return nil
+}
+
+// GetSource returns the operator source with default fallback.
+func (o *Operator) GetSource(defaultSource string) string {
+	if o.Source != "" {
+		return o.Source
+	}
+	return defaultSource
+}
+
+// GetSourceNamespace returns the source namespace with default fallback.
+func (o *Operator) GetSourceNamespace(defaultSourceNamespace string) string {
+	if o.SourceNamespace != "" {
+		return o.SourceNamespace
+	}
+	return defaultSourceNamespace
+}
+
+// GetChannel returns the channel with a default fallback.
+func (o *Operator) GetChannel() string {
+	if o.Channel != "" {
+		return o.Channel
+	}
+	return "stable"
+}
+
+// GetInstallPlanApproval returns the install plan approval with default.
+func (o *Operator) GetInstallPlanApproval() string {
+	if o.InstallPlanApproval != "" {
+		return o.InstallPlanApproval
+	}
+	return "Automatic"
+}
+
+// GetInstallMode returns the install mode with default.
+func (o *Operator) GetInstallMode() InstallMode {
+	if o.InstallMode != "" {
+		return InstallMode(o.InstallMode)
+	}
+	return InstallModeOwnNamespace
+}
+
+// SubscriptionManifest represents the data needed for Subscription template.
+type SubscriptionManifest struct {
+	Name                string
+	Namespace           string
+	Channel             string
+	Source              string
+	SourceNamespace     string
+	InstallPlanApproval string
+	StartingCSV         string
+}
+
+// GroupManifest represents the data needed for OperatorGroup template.
+type GroupManifest struct {
+	Name             string
+	Namespace        string
+	TargetNamespaces []string
+}
+
+// ToSubscriptionManifest converts an Operator to SubscriptionManifest.
+func (o *Operator) ToSubscriptionManifest(defaultSource, defaultSourceNamespace string) SubscriptionManifest {
+	return SubscriptionManifest{
+		Name:                o.Name,
+		Namespace:           o.Namespace,
+		Channel:             o.GetChannel(),
+		Source:              o.GetSource(defaultSource),
+		SourceNamespace:     o.GetSourceNamespace(defaultSourceNamespace),
+		InstallPlanApproval: o.GetInstallPlanApproval(),
+		StartingCSV:         o.Version,
+	}
+}
+
+// ToGroupManifest converts an Operator to GroupManifest.
+func (o *Operator) ToGroupManifest() GroupManifest {
+	targetNamespaces := o.TargetNamespaces
+	if len(targetNamespaces) == 0 {
+		switch o.GetInstallMode() {
+		case InstallModeOwnNamespace, InstallModeSingleNamespace:
+			targetNamespaces = []string{o.Namespace}
+		case InstallModeAllNamespaces:
+			targetNamespaces = []string{} // Empty means all namespaces
+		}
+	}
+	return GroupManifest{
+		Name:             o.Name + "-og",
+		Namespace:        o.Namespace,
+		TargetNamespaces: targetNamespaces,
+	}
+}
+
+// Manager handles operator management operations.
+type Manager struct {
+	config Config
+}
+
+// NewManager creates a new operator manager.
+func NewManager(config Config) *Manager {
+	return &Manager{config: config}
+}
+
+// GetEnabledOperators returns all enabled operators.
+func (m *Manager) GetEnabledOperators() []Operator {
+	var enabled []Operator
+	for i := range m.config.Operators {
+		if m.config.Operators[i].Enabled {
+			enabled = append(enabled, m.config.Operators[i])
+		}
+	}
+	return enabled
+}
+
+// AddOperator adds an operator to the configuration.
+func (m *Manager) AddOperator(op *Operator) error {
+	if err := op.Validate(); err != nil {
+		return err
+	}
+	m.config.Operators = append(m.config.Operators, *op)
+	return nil
+}
+
+// AddPreset adds a preset operator by name.
+func (m *Manager) AddPreset(name string) error {
+	preset, ok := GetOperatorPreset(name)
+	if !ok {
+		return fmt.Errorf("unknown operator preset: %s", name)
+	}
+	return m.AddOperator(preset)
+}
+
+// RemoveOperator removes an operator by name.
+func (m *Manager) RemoveOperator(name string) bool {
+	for i := range m.config.Operators {
+		if m.config.Operators[i].Name == name {
+			m.config.Operators = append(m.config.Operators[:i], m.config.Operators[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// GetOperator returns an operator by name.
+func (m *Manager) GetOperator(name string) (*Operator, bool) {
+	for i := range m.config.Operators {
+		if m.config.Operators[i].Name == name {
+			return &m.config.Operators[i], true
+		}
+	}
+	return nil, false
+}
+
+// ValidateAll validates all operators in the configuration.
+func (m *Manager) ValidateAll() []error {
+	var errors []error
+	for i := range m.config.Operators {
+		if err := m.config.Operators[i].Validate(); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return errors
+}
+
+// GetConfig returns the operator configuration.
+func (m *Manager) GetConfig() Config {
+	return m.config
+}

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -1,0 +1,444 @@
+package operator
+
+import (
+	"testing"
+)
+
+func TestOperator_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      Operator
+		wantErr bool
+	}{
+		{
+			name: "valid operator",
+			op: Operator{
+				Name:      "test-operator",
+				Namespace: "test-ns",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			op: Operator{
+				Namespace: "test-ns",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing namespace",
+			op: Operator{
+				Name: "test-operator",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid install mode",
+			op: Operator{
+				Name:        "test-operator",
+				Namespace:   "test-ns",
+				InstallMode: "AllNamespaces",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid install mode",
+			op: Operator{
+				Name:        "test-operator",
+				Namespace:   "test-ns",
+				InstallMode: "InvalidMode",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.op.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOperator_GetSource(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        string
+		defaultSource string
+		want          string
+	}{
+		{"custom source", "custom-operators", "community-operators", "custom-operators"},
+		{"default source", "", "community-operators", "community-operators"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := Operator{Source: tt.source}
+			if got := op.GetSource(tt.defaultSource); got != tt.want {
+				t.Errorf("GetSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperator_GetChannel(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel string
+		want    string
+	}{
+		{"custom channel", "beta", "beta"},
+		{"default channel", "", "stable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := Operator{Channel: tt.channel}
+			if got := op.GetChannel(); got != tt.want {
+				t.Errorf("GetChannel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperator_GetInstallPlanApproval(t *testing.T) {
+	tests := []struct {
+		name     string
+		approval string
+		want     string
+	}{
+		{"manual approval", "Manual", "Manual"},
+		{"default approval", "", "Automatic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := Operator{InstallPlanApproval: tt.approval}
+			if got := op.GetInstallPlanApproval(); got != tt.want {
+				t.Errorf("GetInstallPlanApproval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperator_GetInstallMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		installMode string
+		want        InstallMode
+	}{
+		{"all namespaces", "AllNamespaces", InstallModeAllNamespaces},
+		{"own namespace", "OwnNamespace", InstallModeOwnNamespace},
+		{"default", "", InstallModeOwnNamespace},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := Operator{InstallMode: tt.installMode}
+			if got := op.GetInstallMode(); got != tt.want {
+				t.Errorf("GetInstallMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperator_ToSubscriptionManifest(t *testing.T) {
+	op := Operator{
+		Name:                "test-operator",
+		Namespace:           "test-ns",
+		Channel:             "beta",
+		Source:              "custom-operators",
+		SourceNamespace:     "custom-marketplace",
+		InstallPlanApproval: "Manual",
+		Version:             "1.0.0",
+	}
+
+	manifest := op.ToSubscriptionManifest("default-source", "default-ns")
+
+	if manifest.Name != "test-operator" {
+		t.Errorf("Name = %v, want test-operator", manifest.Name)
+	}
+	if manifest.Namespace != "test-ns" {
+		t.Errorf("Namespace = %v, want test-ns", manifest.Namespace)
+	}
+	if manifest.Channel != "beta" {
+		t.Errorf("Channel = %v, want beta", manifest.Channel)
+	}
+	if manifest.Source != "custom-operators" {
+		t.Errorf("Source = %v, want custom-operators", manifest.Source)
+	}
+	if manifest.SourceNamespace != "custom-marketplace" {
+		t.Errorf("SourceNamespace = %v, want custom-marketplace", manifest.SourceNamespace)
+	}
+	if manifest.InstallPlanApproval != "Manual" {
+		t.Errorf("InstallPlanApproval = %v, want Manual", manifest.InstallPlanApproval)
+	}
+	if manifest.StartingCSV != "1.0.0" {
+		t.Errorf("StartingCSV = %v, want 1.0.0", manifest.StartingCSV)
+	}
+}
+
+func TestOperator_ToGroupManifest(t *testing.T) {
+	tests := []struct {
+		name                 string
+		op                   Operator
+		wantTargetNamespaces []string
+	}{
+		{
+			name: "own namespace",
+			op: Operator{
+				Name:        "test-operator",
+				Namespace:   "test-ns",
+				InstallMode: "OwnNamespace",
+			},
+			wantTargetNamespaces: []string{"test-ns"},
+		},
+		{
+			name: "all namespaces",
+			op: Operator{
+				Name:        "test-operator",
+				Namespace:   "test-ns",
+				InstallMode: "AllNamespaces",
+			},
+			wantTargetNamespaces: []string{},
+		},
+		{
+			name: "custom target namespaces",
+			op: Operator{
+				Name:             "test-operator",
+				Namespace:        "test-ns",
+				TargetNamespaces: []string{"ns1", "ns2"},
+			},
+			wantTargetNamespaces: []string{"ns1", "ns2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := tt.op.ToGroupManifest()
+			if len(manifest.TargetNamespaces) != len(tt.wantTargetNamespaces) {
+				t.Errorf("TargetNamespaces length = %v, want %v", len(manifest.TargetNamespaces), len(tt.wantTargetNamespaces))
+			}
+		})
+	}
+}
+
+func TestGetOperatorPreset(t *testing.T) {
+	tests := []struct {
+		name   string
+		preset string
+		want   bool
+	}{
+		{"prometheus", "prometheus", true},
+		{"grafana", "grafana", true},
+		{"cert-manager", "cert-manager", true},
+		{"unknown", "unknown-operator", false},
+		{"case insensitive", "PROMETHEUS", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := GetOperatorPreset(tt.preset)
+			if ok != tt.want {
+				t.Errorf("GetOperatorPreset(%s) ok = %v, want %v", tt.preset, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestListOperatorPresets(t *testing.T) {
+	presets := ListOperatorPresets()
+	if len(presets) == 0 {
+		t.Error("ListOperatorPresets() should return non-empty list")
+	}
+
+	// Check that expected presets are in the list
+	expected := []string{"prometheus", "grafana", "cert-manager"}
+	for _, e := range expected {
+		found := false
+		for _, p := range presets {
+			if p == e {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected preset %s not found in list", e)
+		}
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	config := NewDefaultConfig()
+
+	if config.Enabled {
+		t.Error("Default config should have Enabled = false")
+	}
+	if len(config.Operators) != 0 {
+		t.Error("Default config should have empty Operators list")
+	}
+	if !config.CreateOperatorGroup {
+		t.Error("Default config should have CreateOperatorGroup = true")
+	}
+	if config.DefaultSource != string(CatalogSourceCommunity) {
+		t.Errorf("DefaultSource = %v, want %v", config.DefaultSource, CatalogSourceCommunity)
+	}
+}
+
+func TestManager_AddOperator(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	op := &Operator{
+		Name:      "test-operator",
+		Namespace: "test-ns",
+		Enabled:   true,
+	}
+
+	err := manager.AddOperator(op)
+	if err != nil {
+		t.Errorf("AddOperator() error = %v", err)
+	}
+
+	if len(manager.GetConfig().Operators) != 1 {
+		t.Error("Operator should be added")
+	}
+}
+
+func TestManager_AddOperator_Invalid(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	op := &Operator{
+		Name: "test-operator",
+		// Missing namespace
+	}
+
+	err := manager.AddOperator(op)
+	if err == nil {
+		t.Error("AddOperator() should fail for invalid operator")
+	}
+}
+
+func TestManager_AddPreset(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	err := manager.AddPreset("prometheus")
+	if err != nil {
+		t.Errorf("AddPreset() error = %v", err)
+	}
+
+	if len(manager.GetConfig().Operators) != 1 {
+		t.Error("Preset operator should be added")
+	}
+
+	op, ok := manager.GetOperator("prometheus-operator")
+	if !ok {
+		t.Error("Should find prometheus-operator")
+	}
+	if op.Channel == "" {
+		t.Error("Preset should have channel set")
+	}
+}
+
+func TestManager_AddPreset_Unknown(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	err := manager.AddPreset("unknown-preset")
+	if err == nil {
+		t.Error("AddPreset() should fail for unknown preset")
+	}
+}
+
+func TestManager_RemoveOperator(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	_ = manager.AddOperator(&Operator{Name: "op1", Namespace: "ns1"})
+	_ = manager.AddOperator(&Operator{Name: "op2", Namespace: "ns2"})
+
+	removed := manager.RemoveOperator("op1")
+	if !removed {
+		t.Error("RemoveOperator() should return true")
+	}
+
+	if len(manager.GetConfig().Operators) != 1 {
+		t.Error("Should have 1 operator after removal")
+	}
+
+	_, ok := manager.GetOperator("op1")
+	if ok {
+		t.Error("op1 should be removed")
+	}
+}
+
+func TestManager_RemoveOperator_NotFound(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	removed := manager.RemoveOperator("nonexistent")
+	if removed {
+		t.Error("RemoveOperator() should return false for nonexistent operator")
+	}
+}
+
+func TestManager_GetEnabledOperators(t *testing.T) {
+	config := NewDefaultConfig()
+	config.Operators = []Operator{
+		{Name: "op1", Namespace: "ns1", Enabled: true},
+		{Name: "op2", Namespace: "ns2", Enabled: false},
+		{Name: "op3", Namespace: "ns3", Enabled: true},
+	}
+	manager := NewManager(config)
+
+	enabled := manager.GetEnabledOperators()
+	if len(enabled) != 2 {
+		t.Errorf("GetEnabledOperators() count = %d, want 2", len(enabled))
+	}
+}
+
+func TestManager_ValidateAll(t *testing.T) {
+	config := NewDefaultConfig()
+	config.Operators = []Operator{
+		{Name: "op1", Namespace: "ns1"}, // Valid
+		{Name: "op2"},                   // Invalid - no namespace
+		{Name: "", Namespace: "ns3"},    // Invalid - no name
+	}
+	manager := NewManager(config)
+
+	errors := manager.ValidateAll()
+	if len(errors) != 2 {
+		t.Errorf("ValidateAll() errors count = %d, want 2", len(errors))
+	}
+}
+
+func TestInstallModeConstants(t *testing.T) {
+	if InstallModeOwnNamespace != "OwnNamespace" {
+		t.Error("InstallModeOwnNamespace constant wrong")
+	}
+	if InstallModeSingleNamespace != "SingleNamespace" {
+		t.Error("InstallModeSingleNamespace constant wrong")
+	}
+	if InstallModeMultiNamespace != "MultiNamespace" {
+		t.Error("InstallModeMultiNamespace constant wrong")
+	}
+	if InstallModeAllNamespaces != "AllNamespaces" {
+		t.Error("InstallModeAllNamespaces constant wrong")
+	}
+}
+
+func TestCatalogSourceConstants(t *testing.T) {
+	if CatalogSourceCommunity != "community-operators" {
+		t.Error("CatalogSourceCommunity constant wrong")
+	}
+	if CatalogSourceRedHat != "redhat-operators" {
+		t.Error("CatalogSourceRedHat constant wrong")
+	}
+	if CatalogSourceCertified != "certified-operators" {
+		t.Error("CatalogSourceCertified constant wrong")
+	}
+}

--- a/internal/templates/files/operators/operatorgroup.yaml.tmpl
+++ b/internal/templates/files/operators/operatorgroup.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+{{- if .TargetNamespaces}}
+  targetNamespaces:
+{{- range .TargetNamespaces}}
+    - {{.}}
+{{- end}}
+{{- end}}
+

--- a/internal/templates/files/operators/subscription.yaml.tmpl
+++ b/internal/templates/files/operators/subscription.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  channel: {{.Channel}}
+  name: {{.Name}}
+  source: {{.Source}}
+  sourceNamespace: {{.SourceNamespace}}
+  installPlanApproval: {{.InstallPlanApproval}}
+{{- if .StartingCSV}}
+  startingCSV: {{.StartingCSV}}
+{{- end}}
+


### PR DESCRIPTION
## Summary
Implements Kubernetes Operator management for GitOps infrastructure using OLM.

## Changes
- Add `internal/operator` package
- Implement `Operator` struct with OLM subscription configuration
- Add common operator presets
- Implement `Manager` for operator lifecycle
- Add Subscription and OperatorGroup YAML templates
- Comprehensive unit tests

## Operator Presets
| Name | Package | Source | Use Case |
|------|---------|--------|----------|
| prometheus | prometheus-operator | community | Monitoring |
| grafana | grafana-operator | community | Visualization |
| cert-manager | cert-manager | community | Certificate management |
| external-secrets | external-secrets-operator | community | Secret management |
| sealed-secrets | sealed-secrets-operator-helm | community | Encrypted secrets |
| kyverno | kyverno-operator | community | Policy enforcement |
| opa-gatekeeper | gatekeeper-operator-product | redhat | Policy enforcement |
| elasticsearch | elasticsearch-operator | redhat | Logging |
| jaeger | jaeger-product | redhat | Distributed tracing |
| servicemesh | servicemeshoperator | redhat | Service mesh |

## Usage
```yaml
operators:
  enabled: true
  create_operator_group: true
  operators:
    - name: prometheus-operator
      namespace: monitoring
      channel: beta
      enabled: true
```

## Testing
- All unit tests pass

Closes #15