### PR TITLE
feat(multirepo): add multi-repository support

### DIFF
--- a/internal/multirepo/multirepo.go
+++ b/internal/multirepo/multirepo.go
@@ -1,0 +1,395 @@
+// Package multirepo provides multi-repository support for GitOps.
+package multirepo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Repository represents a Git repository configuration.
+type Repository struct {
+	// Name is the unique identifier for this repository
+	Name string `yaml:"name" json:"name"`
+	// URL is the Git repository URL
+	URL string `yaml:"url" json:"url"`
+	// Branch is the default branch to use
+	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	// Path is the base path within the repository
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+	// Type indicates what this repository contains
+	Type RepositoryType `yaml:"type" json:"type"`
+	// Credentials holds authentication configuration
+	Credentials *Credentials `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	// SyncPolicy defines how to sync from this repo
+	SyncPolicy *SyncPolicy `yaml:"sync_policy,omitempty" json:"sync_policy,omitempty"`
+}
+
+// RepositoryType defines the type of content in a repository.
+type RepositoryType string
+
+const (
+	// RepoTypeMonorepo contains everything in one repository
+	RepoTypeMonorepo RepositoryType = "monorepo"
+	// RepoTypeApplications contains only application manifests
+	RepoTypeApplications RepositoryType = "applications"
+	// RepoTypeInfrastructure contains only infrastructure manifests
+	RepoTypeInfrastructure RepositoryType = "infrastructure"
+	// RepoTypeConfig contains cluster/environment configuration
+	RepoTypeConfig RepositoryType = "config"
+	// RepoTypeHelmCharts contains Helm charts
+	RepoTypeHelmCharts RepositoryType = "helm-charts"
+	// RepoTypeKustomize contains Kustomize bases
+	RepoTypeKustomize RepositoryType = "kustomize"
+)
+
+// Credentials holds repository authentication configuration.
+type Credentials struct {
+	// Type is the credential type: ssh, token, basic
+	Type string `yaml:"type" json:"type"`
+	// SecretRef references a Kubernetes Secret
+	SecretRef *SecretRef `yaml:"secret_ref,omitempty" json:"secret_ref,omitempty"`
+	// SSHPrivateKeyPath is the path to SSH private key (for local use)
+	SSHPrivateKeyPath string `yaml:"ssh_private_key_path,omitempty" json:"ssh_private_key_path,omitempty"`
+	// Username for basic auth
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	// TokenEnv is the environment variable containing the token
+	TokenEnv string `yaml:"token_env,omitempty" json:"token_env,omitempty"`
+}
+
+// SecretRef references a Kubernetes Secret.
+type SecretRef struct {
+	// Name of the Secret
+	Name string `yaml:"name" json:"name"`
+	// Namespace of the Secret
+	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	// Key in the Secret data
+	Key string `yaml:"key,omitempty" json:"key,omitempty"`
+}
+
+// SyncPolicy defines how ArgoCD should sync from this repository.
+type SyncPolicy struct {
+	// Automated enables automatic sync
+	Automated bool `yaml:"automated,omitempty" json:"automated,omitempty"`
+	// Prune enables automatic pruning
+	Prune bool `yaml:"prune,omitempty" json:"prune,omitempty"`
+	// SelfHeal enables automatic self-healing
+	SelfHeal bool `yaml:"self_heal,omitempty" json:"self_heal,omitempty"`
+	// SyncOptions are additional sync options
+	SyncOptions []string `yaml:"sync_options,omitempty" json:"sync_options,omitempty"`
+}
+
+// Config holds the multi-repository configuration.
+type Config struct {
+	// Enabled controls whether multi-repo support is enabled
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Primary is the main repository (usually the GitOps repo itself)
+	Primary *Repository `yaml:"primary,omitempty" json:"primary,omitempty"`
+	// Repositories is the list of additional repositories
+	Repositories []Repository `yaml:"repositories,omitempty" json:"repositories,omitempty"`
+	// ApplicationMappings maps applications to repositories
+	ApplicationMappings []ApplicationMapping `yaml:"application_mappings,omitempty" json:"application_mappings,omitempty"`
+}
+
+// ApplicationMapping maps an application to a specific repository.
+type ApplicationMapping struct {
+	// Application is the application name or pattern (supports wildcards)
+	Application string `yaml:"application" json:"application"`
+	// Repository is the repository name to use
+	Repository string `yaml:"repository" json:"repository"`
+	// Path overrides the repository's default path
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+	// Branch overrides the repository's default branch
+	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+}
+
+// NewDefaultConfig creates a default multi-repo configuration.
+func NewDefaultConfig() Config {
+	return Config{
+		Enabled:             false,
+		Repositories:        []Repository{},
+		ApplicationMappings: []ApplicationMapping{},
+	}
+}
+
+// Validate validates the repository configuration.
+func (r *Repository) Validate() error {
+	if r.Name == "" {
+		return fmt.Errorf("repository name is required")
+	}
+	if r.URL == "" {
+		return fmt.Errorf("repository URL is required for %s", r.Name)
+	}
+	if r.Type == "" {
+		return fmt.Errorf("repository type is required for %s", r.Name)
+	}
+
+	validTypes := []RepositoryType{
+		RepoTypeMonorepo,
+		RepoTypeApplications,
+		RepoTypeInfrastructure,
+		RepoTypeConfig,
+		RepoTypeHelmCharts,
+		RepoTypeKustomize,
+	}
+	valid := false
+	for _, t := range validTypes {
+		if r.Type == t {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("invalid repository type: %s", r.Type)
+	}
+
+	return nil
+}
+
+// GetBranch returns the branch with default fallback.
+func (r *Repository) GetBranch() string {
+	if r.Branch != "" {
+		return r.Branch
+	}
+	return "main"
+}
+
+// GetPath returns the path with default fallback.
+func (r *Repository) GetPath() string {
+	if r.Path != "" {
+		return r.Path
+	}
+	return "."
+}
+
+// GetCredentialType returns the credential type with default.
+func (r *Repository) GetCredentialType() string {
+	if r.Credentials != nil && r.Credentials.Type != "" {
+		return r.Credentials.Type
+	}
+	// Try to infer from URL
+	if strings.HasPrefix(r.URL, "git@") || strings.Contains(r.URL, "ssh://") {
+		return "ssh"
+	}
+	return "https"
+}
+
+// Manager handles multi-repository operations.
+type Manager struct {
+	config Config
+}
+
+// NewManager creates a new multi-repo manager.
+func NewManager(config Config) *Manager {
+	return &Manager{config: config}
+}
+
+// GetConfig returns the current configuration.
+func (m *Manager) GetConfig() Config {
+	return m.config
+}
+
+// AddRepository adds a repository to the configuration.
+func (m *Manager) AddRepository(repo *Repository) error {
+	if err := repo.Validate(); err != nil {
+		return err
+	}
+
+	// Check for duplicate names
+	for _, existing := range m.config.Repositories {
+		if existing.Name == repo.Name {
+			return fmt.Errorf("repository with name %s already exists", repo.Name)
+		}
+	}
+
+	m.config.Repositories = append(m.config.Repositories, *repo)
+	return nil
+}
+
+// RemoveRepository removes a repository by name.
+func (m *Manager) RemoveRepository(name string) bool {
+	for i, repo := range m.config.Repositories {
+		if repo.Name == name {
+			m.config.Repositories = append(m.config.Repositories[:i], m.config.Repositories[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// GetRepository returns a repository by name.
+func (m *Manager) GetRepository(name string) (*Repository, bool) {
+	for i := range m.config.Repositories {
+		if m.config.Repositories[i].Name == name {
+			return &m.config.Repositories[i], true
+		}
+	}
+	return nil, false
+}
+
+// ListRepositories returns all configured repositories.
+func (m *Manager) ListRepositories() []Repository {
+	return m.config.Repositories
+}
+
+// AddMapping adds an application mapping.
+func (m *Manager) AddMapping(mapping ApplicationMapping) error {
+	if mapping.Application == "" {
+		return fmt.Errorf("application name/pattern is required")
+	}
+	if mapping.Repository == "" {
+		return fmt.Errorf("repository name is required")
+	}
+
+	// Verify repository exists
+	if _, exists := m.GetRepository(mapping.Repository); !exists {
+		if m.config.Primary == nil || m.config.Primary.Name != mapping.Repository {
+			return fmt.Errorf("repository %s does not exist", mapping.Repository)
+		}
+	}
+
+	m.config.ApplicationMappings = append(m.config.ApplicationMappings, mapping)
+	return nil
+}
+
+// GetMappingForApplication finds the mapping for an application.
+func (m *Manager) GetMappingForApplication(appName string) (*ApplicationMapping, bool) {
+	// First try exact match
+	for i, mapping := range m.config.ApplicationMappings {
+		if mapping.Application == appName {
+			return &m.config.ApplicationMappings[i], true
+		}
+	}
+
+	// Then try wildcard match
+	for i, mapping := range m.config.ApplicationMappings {
+		if matchWildcard(mapping.Application, appName) {
+			return &m.config.ApplicationMappings[i], true
+		}
+	}
+
+	return nil, false
+}
+
+// GetRepositoryForApplication returns the repository for an application.
+func (m *Manager) GetRepositoryForApplication(appName string) (*Repository, error) {
+	mapping, found := m.GetMappingForApplication(appName)
+	if !found {
+		// Return primary if no mapping found
+		if m.config.Primary != nil {
+			return m.config.Primary, nil
+		}
+		return nil, fmt.Errorf("no repository mapping found for application: %s", appName)
+	}
+
+	repo, exists := m.GetRepository(mapping.Repository)
+	if !exists {
+		if m.config.Primary != nil && m.config.Primary.Name == mapping.Repository {
+			return m.config.Primary, nil
+		}
+		return nil, fmt.Errorf("mapped repository %s not found", mapping.Repository)
+	}
+
+	return repo, nil
+}
+
+// SetPrimary sets the primary repository.
+func (m *Manager) SetPrimary(repo *Repository) error {
+	if err := repo.Validate(); err != nil {
+		return err
+	}
+	m.config.Primary = repo
+	return nil
+}
+
+// GetPrimary returns the primary repository.
+func (m *Manager) GetPrimary() *Repository {
+	return m.config.Primary
+}
+
+// ValidateAll validates all repositories and mappings.
+func (m *Manager) ValidateAll() []error {
+	var errors []error
+
+	if m.config.Primary != nil {
+		if err := m.config.Primary.Validate(); err != nil {
+			errors = append(errors, fmt.Errorf("primary repository: %w", err))
+		}
+	}
+
+	for i := range m.config.Repositories {
+		if err := m.config.Repositories[i].Validate(); err != nil {
+			errors = append(errors, fmt.Errorf("repository %s: %w", m.config.Repositories[i].Name, err))
+		}
+	}
+
+	for _, mapping := range m.config.ApplicationMappings {
+		if _, exists := m.GetRepository(mapping.Repository); !exists {
+			if m.config.Primary == nil || m.config.Primary.Name != mapping.Repository {
+				errors = append(errors, fmt.Errorf("mapping references non-existent repository: %s", mapping.Repository))
+			}
+		}
+	}
+
+	return errors
+}
+
+// GetRepositoriesByType returns repositories of a specific type.
+func (m *Manager) GetRepositoriesByType(repoType RepositoryType) []Repository {
+	var repos []Repository
+	for _, repo := range m.config.Repositories {
+		if repo.Type == repoType {
+			repos = append(repos, repo)
+		}
+	}
+	return repos
+}
+
+// matchWildcard performs simple wildcard matching.
+func matchWildcard(pattern, str string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasPrefix(pattern, "*") && strings.HasSuffix(pattern, "*") {
+		return strings.Contains(str, pattern[1:len(pattern)-1])
+	}
+	if strings.HasPrefix(pattern, "*") {
+		return strings.HasSuffix(str, pattern[1:])
+	}
+	if strings.HasSuffix(pattern, "*") {
+		return strings.HasPrefix(str, pattern[:len(pattern)-1])
+	}
+	return pattern == str
+}
+
+// RepositoryManifest holds data for ArgoCD repository secret template.
+type RepositoryManifest struct {
+	Name          string
+	Namespace     string
+	URL           string
+	Type          string // git, helm
+	Username      string
+	Password      string
+	SSHPrivateKey string
+	TLSClientCert string
+	TLSClientKey  string
+	Insecure      bool
+	EnableLFS     bool
+	Project       string
+}
+
+// ToRepositoryManifest creates an ArgoCD repository manifest from Repository.
+func (r *Repository) ToRepositoryManifest(namespace, project string) RepositoryManifest {
+	manifest := RepositoryManifest{
+		Name:      r.Name,
+		Namespace: namespace,
+		URL:       r.URL,
+		Type:      "git",
+		Project:   project,
+	}
+
+	if r.Type == RepoTypeHelmCharts {
+		manifest.Type = "helm"
+	}
+
+	return manifest
+}

--- a/internal/multirepo/multirepo_test.go
+++ b/internal/multirepo/multirepo_test.go
@@ -1,0 +1,466 @@
+package multirepo
+
+import (
+	"testing"
+)
+
+func TestRepository_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		repo    Repository
+		wantErr bool
+	}{
+		{
+			name: "valid repository",
+			repo: Repository{
+				Name: "test-repo",
+				URL:  "https://github.com/org/repo",
+				Type: RepoTypeApplications,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			repo: Repository{
+				URL:  "https://github.com/org/repo",
+				Type: RepoTypeApplications,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing URL",
+			repo: Repository{
+				Name: "test-repo",
+				Type: RepoTypeApplications,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing type",
+			repo: Repository{
+				Name: "test-repo",
+				URL:  "https://github.com/org/repo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid type",
+			repo: Repository{
+				Name: "test-repo",
+				URL:  "https://github.com/org/repo",
+				Type: "invalid-type",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.repo.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRepository_GetBranch(t *testing.T) {
+	tests := []struct {
+		name   string
+		branch string
+		want   string
+	}{
+		{"custom branch", "develop", "develop"},
+		{"default branch", "", "main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := Repository{Branch: tt.branch}
+			if got := repo.GetBranch(); got != tt.want {
+				t.Errorf("GetBranch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepository_GetPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"custom path", "apps/production", "apps/production"},
+		{"default path", "", "."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := Repository{Path: tt.path}
+			if got := repo.GetPath(); got != tt.want {
+				t.Errorf("GetPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepository_GetCredentialType(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		credentials *Credentials
+		want        string
+	}{
+		{"https URL", "https://github.com/org/repo", nil, "https"},
+		{"ssh git@ URL", "git@github.com:org/repo.git", nil, "ssh"},
+		{"ssh:// URL", "ssh://git@github.com/org/repo", nil, "ssh"},
+		{"explicit token", "https://github.com/org/repo", &Credentials{Type: "token"}, "token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := Repository{URL: tt.url, Credentials: tt.credentials}
+			if got := repo.GetCredentialType(); got != tt.want {
+				t.Errorf("GetCredentialType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	config := NewDefaultConfig()
+	manager := NewManager(config)
+
+	if manager == nil {
+		t.Fatal("NewManager returned nil")
+	}
+	if manager.config.Enabled {
+		t.Error("Default config should have Enabled = false")
+	}
+}
+
+func TestManager_AddRepository(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	repo := &Repository{
+		Name: "test-repo",
+		URL:  "https://github.com/org/repo",
+		Type: RepoTypeApplications,
+	}
+
+	err := manager.AddRepository(repo)
+	if err != nil {
+		t.Errorf("AddRepository() error = %v", err)
+	}
+
+	if len(manager.ListRepositories()) != 1 {
+		t.Error("Repository should be added")
+	}
+}
+
+func TestManager_AddRepository_Duplicate(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	repo := &Repository{
+		Name: "test-repo",
+		URL:  "https://github.com/org/repo",
+		Type: RepoTypeApplications,
+	}
+
+	_ = manager.AddRepository(repo)
+	err := manager.AddRepository(repo)
+	if err == nil {
+		t.Error("AddRepository() should fail for duplicate name")
+	}
+}
+
+func TestManager_AddRepository_Invalid(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	repo := &Repository{
+		Name: "test-repo",
+		// Missing URL
+	}
+
+	err := manager.AddRepository(repo)
+	if err == nil {
+		t.Error("AddRepository() should fail for invalid repository")
+	}
+}
+
+func TestManager_RemoveRepository(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	_ = manager.AddRepository(&Repository{Name: "repo1", URL: "https://url1", Type: RepoTypeApplications})
+	_ = manager.AddRepository(&Repository{Name: "repo2", URL: "https://url2", Type: RepoTypeInfrastructure})
+
+	removed := manager.RemoveRepository("repo1")
+	if !removed {
+		t.Error("RemoveRepository() should return true")
+	}
+
+	if len(manager.ListRepositories()) != 1 {
+		t.Error("Should have 1 repository after removal")
+	}
+}
+
+func TestManager_RemoveRepository_NotFound(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	removed := manager.RemoveRepository("nonexistent")
+	if removed {
+		t.Error("RemoveRepository() should return false for nonexistent repo")
+	}
+}
+
+func TestManager_GetRepository(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	_ = manager.AddRepository(&Repository{Name: "repo1", URL: "https://url1", Type: RepoTypeApplications})
+
+	repo, found := manager.GetRepository("repo1")
+	if !found {
+		t.Error("GetRepository() should find repo1")
+	}
+	if repo.Name != "repo1" {
+		t.Errorf("GetRepository() name = %v, want repo1", repo.Name)
+	}
+
+	_, found = manager.GetRepository("nonexistent")
+	if found {
+		t.Error("GetRepository() should not find nonexistent")
+	}
+}
+
+func TestManager_AddMapping(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+	_ = manager.AddRepository(&Repository{Name: "apps-repo", URL: "https://url", Type: RepoTypeApplications})
+
+	mapping := ApplicationMapping{
+		Application: "my-app",
+		Repository:  "apps-repo",
+	}
+
+	err := manager.AddMapping(mapping)
+	if err != nil {
+		t.Errorf("AddMapping() error = %v", err)
+	}
+}
+
+func TestManager_AddMapping_InvalidRepo(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	mapping := ApplicationMapping{
+		Application: "my-app",
+		Repository:  "nonexistent-repo",
+	}
+
+	err := manager.AddMapping(mapping)
+	if err == nil {
+		t.Error("AddMapping() should fail for nonexistent repository")
+	}
+}
+
+func TestManager_GetMappingForApplication(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+	_ = manager.AddRepository(&Repository{Name: "apps-repo", URL: "https://url", Type: RepoTypeApplications})
+
+	// Add exact match mapping
+	_ = manager.AddMapping(ApplicationMapping{Application: "my-app", Repository: "apps-repo"})
+	// Add wildcard mapping
+	_ = manager.AddMapping(ApplicationMapping{Application: "frontend-*", Repository: "apps-repo"})
+
+	tests := []struct {
+		name    string
+		appName string
+		want    bool
+	}{
+		{"exact match", "my-app", true},
+		{"wildcard match", "frontend-service", true},
+		{"no match", "backend-api", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, found := manager.GetMappingForApplication(tt.appName)
+			if found != tt.want {
+				t.Errorf("GetMappingForApplication(%s) found = %v, want %v", tt.appName, found, tt.want)
+			}
+		})
+	}
+}
+
+func TestManager_SetPrimary(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	repo := &Repository{
+		Name: "primary-repo",
+		URL:  "https://github.com/org/main-repo",
+		Type: RepoTypeMonorepo,
+	}
+
+	err := manager.SetPrimary(repo)
+	if err != nil {
+		t.Errorf("SetPrimary() error = %v", err)
+	}
+
+	primary := manager.GetPrimary()
+	if primary == nil {
+		t.Fatal("GetPrimary() should not return nil")
+	}
+	if primary.Name != "primary-repo" {
+		t.Errorf("Primary name = %v, want primary-repo", primary.Name)
+	}
+}
+
+func TestManager_GetRepositoryForApplication(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+
+	// Set up primary
+	_ = manager.SetPrimary(&Repository{Name: "main", URL: "https://main", Type: RepoTypeMonorepo})
+
+	// Add specific repo and mapping
+	_ = manager.AddRepository(&Repository{Name: "apps", URL: "https://apps", Type: RepoTypeApplications})
+	_ = manager.AddMapping(ApplicationMapping{Application: "frontend-*", Repository: "apps"})
+
+	tests := []struct {
+		name     string
+		appName  string
+		wantRepo string
+		wantErr  bool
+	}{
+		{"mapped app", "frontend-web", "apps", false},
+		{"unmapped app falls to primary", "backend-api", "main", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, err := manager.GetRepositoryForApplication(tt.appName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetRepositoryForApplication() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && repo.Name != tt.wantRepo {
+				t.Errorf("GetRepositoryForApplication() repo = %v, want %v", repo.Name, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestManager_ValidateAll(t *testing.T) {
+	config := NewDefaultConfig()
+	config.Repositories = []Repository{
+		{Name: "valid", URL: "https://url", Type: RepoTypeApplications},
+		{Name: "invalid"},
+	}
+	manager := NewManager(config)
+
+	errors := manager.ValidateAll()
+	if len(errors) != 1 {
+		t.Errorf("ValidateAll() errors count = %d, want 1", len(errors))
+	}
+}
+
+func TestManager_GetRepositoriesByType(t *testing.T) {
+	manager := NewManager(NewDefaultConfig())
+	_ = manager.AddRepository(&Repository{Name: "app1", URL: "https://app1", Type: RepoTypeApplications})
+	_ = manager.AddRepository(&Repository{Name: "app2", URL: "https://app2", Type: RepoTypeApplications})
+	_ = manager.AddRepository(&Repository{Name: "infra", URL: "https://infra", Type: RepoTypeInfrastructure})
+
+	apps := manager.GetRepositoriesByType(RepoTypeApplications)
+	if len(apps) != 2 {
+		t.Errorf("GetRepositoriesByType(applications) count = %d, want 2", len(apps))
+	}
+
+	infra := manager.GetRepositoriesByType(RepoTypeInfrastructure)
+	if len(infra) != 1 {
+		t.Errorf("GetRepositoriesByType(infrastructure) count = %d, want 1", len(infra))
+	}
+}
+
+func TestMatchWildcard(t *testing.T) {
+	tests := []struct {
+		pattern string
+		str     string
+		want    bool
+	}{
+		{"*", "anything", true},
+		{"prefix-*", "prefix-app", true},
+		{"prefix-*", "other-app", false},
+		{"*-suffix", "app-suffix", true},
+		{"*-suffix", "app-other", false},
+		{"*middle*", "has-middle-here", true},
+		{"*middle*", "no-match", false},
+		{"exact", "exact", true},
+		{"exact", "different", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.str, func(t *testing.T) {
+			if got := matchWildcard(tt.pattern, tt.str); got != tt.want {
+				t.Errorf("matchWildcard(%q, %q) = %v, want %v", tt.pattern, tt.str, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryTypeConstants(t *testing.T) {
+	if RepoTypeMonorepo != "monorepo" {
+		t.Error("RepoTypeMonorepo constant wrong")
+	}
+	if RepoTypeApplications != "applications" {
+		t.Error("RepoTypeApplications constant wrong")
+	}
+	if RepoTypeInfrastructure != "infrastructure" {
+		t.Error("RepoTypeInfrastructure constant wrong")
+	}
+	if RepoTypeConfig != "config" {
+		t.Error("RepoTypeConfig constant wrong")
+	}
+	if RepoTypeHelmCharts != "helm-charts" {
+		t.Error("RepoTypeHelmCharts constant wrong")
+	}
+	if RepoTypeKustomize != "kustomize" {
+		t.Error("RepoTypeKustomize constant wrong")
+	}
+}
+
+func TestRepository_ToRepositoryManifest(t *testing.T) {
+	repo := Repository{
+		Name: "test-repo",
+		URL:  "https://github.com/org/repo",
+		Type: RepoTypeApplications,
+	}
+
+	manifest := repo.ToRepositoryManifest("argocd", "default")
+
+	if manifest.Name != "test-repo" {
+		t.Errorf("Name = %v, want test-repo", manifest.Name)
+	}
+	if manifest.Namespace != "argocd" {
+		t.Errorf("Namespace = %v, want argocd", manifest.Namespace)
+	}
+	if manifest.URL != "https://github.com/org/repo" {
+		t.Errorf("URL = %v, want https://github.com/org/repo", manifest.URL)
+	}
+	if manifest.Type != "git" {
+		t.Errorf("Type = %v, want git", manifest.Type)
+	}
+	if manifest.Project != "default" {
+		t.Errorf("Project = %v, want default", manifest.Project)
+	}
+}
+
+func TestRepository_ToRepositoryManifest_HelmType(t *testing.T) {
+	repo := Repository{
+		Name: "helm-repo",
+		URL:  "https://charts.helm.sh/stable",
+		Type: RepoTypeHelmCharts,
+	}
+
+	manifest := repo.ToRepositoryManifest("argocd", "default")
+
+	if manifest.Type != "helm" {
+		t.Errorf("Type = %v, want helm", manifest.Type)
+	}
+}


### PR DESCRIPTION
## Summary
Implements multi-repository support enabling components to be sourced from different Git repositories.

## Changes
- Add `internal/multirepo` package
- Implement Repository and Config structures
- Add application-to-repository mapping
- Support various repository types
- Comprehensive unit tests

## Repository Types
| Type | Description |
|------|-------------|
| monorepo | Everything in one repository |
| applications | Application manifests only |
| infrastructure | Infrastructure manifests only |
| config | Cluster/environment configuration |
| helm-charts | Helm chart repositories |
| kustomize | Kustomize base repositories |

## Features
- **Primary Repository**: Designate main GitOps repo
- **Application Mapping**: Route apps to specific repos
- **Wildcard Support**: Pattern-based mapping (e.g., `frontend-*`)
- **Credential Management**: SSH, token, basic auth
- **Sync Policy**: Per-repo sync configuration

## Usage
```yaml
multirepo:
  enabled: true
  primary:
    name: main-gitops
    url: https://github.com/org/gitops
    type: monorepo
  repositories:
    - name: apps
      url: https://github.com/org/applications
      type: applications
  application_mappings:
    - application: "frontend-*"
      repository: apps
```

## Testing
- All unit tests pass

Closes #13