### PR TITLE
feat: Authentication management for Git providers and platforms (#14)

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,870 @@
+// Package auth provides authentication management for Git providers,
+// platforms, and registries in GitOps workflows.
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CredentialType represents the type of credential.
+type CredentialType string
+
+const (
+	// CredentialTypeGit represents Git repository credentials.
+	CredentialTypeGit CredentialType = "git"
+	// CredentialTypePlatform represents platform credentials (K8s, OpenShift).
+	CredentialTypePlatform CredentialType = "platform"
+	// CredentialTypeRegistry represents container registry credentials.
+	CredentialTypeRegistry CredentialType = "registry"
+)
+
+// Method represents the authentication method.
+type Method string
+
+const (
+	// MethodSSH uses SSH key authentication.
+	MethodSSH Method = "ssh"
+	// MethodToken uses personal access token.
+	MethodToken Method = "token"
+	// MethodOAuth uses OAuth authentication.
+	MethodOAuth Method = "oauth"
+	// MethodBasic uses basic auth (username/password).
+	MethodBasic Method = "basic"
+	// MethodServiceAccount uses Kubernetes service account.
+	MethodServiceAccount Method = "service-account"
+	// MethodOIDC uses OpenID Connect.
+	MethodOIDC Method = "oidc"
+	// MethodAWSIRSA uses AWS IAM Roles for Service Accounts.
+	MethodAWSIRSA Method = "aws-irsa"
+	// MethodAzureAAD uses Azure Active Directory Pod Identity.
+	MethodAzureAAD Method = "azure-aad"
+)
+
+// GitProvider represents a Git hosting provider.
+type GitProvider string
+
+const (
+	GitProviderGitHub      GitProvider = "github"
+	GitProviderGitLab      GitProvider = "gitlab"
+	GitProviderBitbucket   GitProvider = "bitbucket"
+	GitProviderAzureDevOps GitProvider = "azure-devops"
+	GitProviderGitea       GitProvider = "gitea"
+)
+
+// PlatformType represents the target platform type.
+type PlatformType string
+
+const (
+	PlatformKubernetes PlatformType = "kubernetes"
+	PlatformOpenShift  PlatformType = "openshift"
+	PlatformAWS        PlatformType = "aws"
+	PlatformAzure      PlatformType = "azure"
+	PlatformGCP        PlatformType = "gcp"
+)
+
+// SecretFormat represents the format for storing secrets.
+type SecretFormat string
+
+const (
+	SecretFormatPlain          SecretFormat = "plain"
+	SecretFormatSealed         SecretFormat = "sealed"
+	SecretFormatSops           SecretFormat = "sops"
+	SecretFormatExternalSecret SecretFormat = "external-secret"
+	SecretFormatVault          SecretFormat = "vault"
+)
+
+// Credential represents a stored credential.
+type Credential struct {
+	// Name is a unique identifier for the credential
+	Name string `yaml:"name" json:"name"`
+	// Type is the credential type (git, platform, registry)
+	Type CredentialType `yaml:"type" json:"type"`
+	// Provider is the service provider (github, gitlab, openshift, etc.)
+	Provider string `yaml:"provider" json:"provider"`
+	// Method is the authentication method
+	Method Method `yaml:"method" json:"method"`
+	// Data contains the actual credential data
+	Data CredentialData `yaml:"data" json:"data"`
+	// Metadata contains additional information
+	Metadata CredentialMetadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	// CreatedAt is when the credential was created
+	CreatedAt time.Time `yaml:"created_at" json:"created_at"`
+	// UpdatedAt is when the credential was last updated
+	UpdatedAt time.Time `yaml:"updated_at" json:"updated_at"`
+}
+
+// CredentialData holds the actual credential values.
+type CredentialData struct {
+	// Token is the access token or API key
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
+	// Username for basic auth
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	// Password for basic auth
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	// SSHPrivateKey is the SSH private key content
+	SSHPrivateKey string `yaml:"ssh_private_key,omitempty" json:"ssh_private_key,omitempty"`
+	// SSHPublicKey is the SSH public key content
+	SSHPublicKey string `yaml:"ssh_public_key,omitempty" json:"ssh_public_key,omitempty"`
+	// SSHKnownHosts is the SSH known_hosts content
+	SSHKnownHosts string `yaml:"ssh_known_hosts,omitempty" json:"ssh_known_hosts,omitempty"`
+	// ClientID for OAuth
+	ClientID string `yaml:"client_id,omitempty" json:"client_id,omitempty"`
+	// ClientSecret for OAuth
+	ClientSecret string `yaml:"client_secret,omitempty" json:"client_secret,omitempty"`
+	// CACert is the CA certificate for TLS verification
+	CACert string `yaml:"ca_cert,omitempty" json:"ca_cert,omitempty"`
+	// TLSCert is the client certificate
+	TLSCert string `yaml:"tls_cert,omitempty" json:"tls_cert,omitempty"`
+	// TLSKey is the client private key
+	TLSKey string `yaml:"tls_key,omitempty" json:"tls_key,omitempty"`
+	// AWSRoleARN for AWS IRSA
+	AWSRoleARN string `yaml:"aws_role_arn,omitempty" json:"aws_role_arn,omitempty"`
+	// AzureTenantID for Azure AAD
+	AzureTenantID string `yaml:"azure_tenant_id,omitempty" json:"azure_tenant_id,omitempty"`
+	// AzureClientID for Azure AAD
+	AzureClientID string `yaml:"azure_client_id,omitempty" json:"azure_client_id,omitempty"`
+}
+
+// CredentialMetadata contains additional information about a credential.
+type CredentialMetadata struct {
+	// Description of the credential
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// URL is the target URL (e.g., Git repo URL, registry URL)
+	URL string `yaml:"url,omitempty" json:"url,omitempty"`
+	// Namespace is the K8s namespace where secrets should be created
+	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	// SecretName is the name of the K8s secret to generate
+	SecretName string `yaml:"secret_name,omitempty" json:"secret_name,omitempty"`
+	// Labels to apply to generated secrets
+	Labels map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// Annotations to apply to generated secrets
+	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	// ExpiresAt is when the credential expires
+	ExpiresAt *time.Time `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`
+}
+
+// Manager handles credential operations.
+type Manager struct {
+	store        Store
+	secretFormat SecretFormat
+}
+
+// Store interface for credential storage.
+type Store interface {
+	// Save stores a credential
+	Save(ctx context.Context, cred *Credential) error
+	// Get retrieves a credential by name
+	Get(ctx context.Context, name string) (*Credential, error)
+	// List returns all credentials of a given type
+	List(ctx context.Context, credType CredentialType) ([]*Credential, error)
+	// Delete removes a credential
+	Delete(ctx context.Context, name string) error
+	// Exists checks if a credential exists
+	Exists(ctx context.Context, name string) (bool, error)
+}
+
+// NewManager creates a new credential manager.
+func NewManager(store Store, format SecretFormat) *Manager {
+	return &Manager{
+		store:        store,
+		secretFormat: format,
+	}
+}
+
+// AddGitCredential adds a Git provider credential.
+func (m *Manager) AddGitCredential(ctx context.Context, opts *GitCredentialOptions) (*Credential, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid git credential options: %w", err)
+	}
+
+	cred := &Credential{
+		Name:      opts.Name,
+		Type:      CredentialTypeGit,
+		Provider:  string(opts.Provider),
+		Method:    opts.Method,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Metadata: CredentialMetadata{
+			Description: opts.Description,
+			URL:         opts.URL,
+			Namespace:   opts.Namespace,
+			SecretName:  opts.SecretName,
+		},
+	}
+
+	// Set credential data based on method
+	switch opts.Method {
+	case MethodSSH:
+		cred.Data.SSHPrivateKey = opts.SSHPrivateKey
+		cred.Data.SSHPublicKey = opts.SSHPublicKey
+		cred.Data.SSHKnownHosts = opts.SSHKnownHosts
+	case MethodToken:
+		cred.Data.Token = opts.Token
+		cred.Data.Username = opts.Username
+	case MethodBasic:
+		cred.Data.Username = opts.Username
+		cred.Data.Password = opts.Password
+	case MethodOAuth:
+		cred.Data.ClientID = opts.ClientID
+		cred.Data.ClientSecret = opts.ClientSecret
+		cred.Data.Token = opts.Token
+	}
+
+	if err := m.store.Save(ctx, cred); err != nil {
+		return nil, fmt.Errorf("failed to save credential: %w", err)
+	}
+
+	return cred, nil
+}
+
+// GitCredentialOptions contains options for creating Git credentials.
+type GitCredentialOptions struct {
+	Name          string
+	Provider      GitProvider
+	Method        Method
+	URL           string
+	Description   string
+	Namespace     string
+	SecretName    string
+	Token         string
+	Username      string
+	Password      string
+	SSHPrivateKey string
+	SSHPublicKey  string
+	SSHKnownHosts string
+	ClientID      string
+	ClientSecret  string
+}
+
+// Validate validates the Git credential options.
+func (o *GitCredentialOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if o.Provider == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if o.Method == "" {
+		return fmt.Errorf("method is required")
+	}
+
+	switch o.Method {
+	case MethodSSH:
+		if o.SSHPrivateKey == "" {
+			return fmt.Errorf("ssh_private_key is required for SSH auth")
+		}
+	case MethodToken:
+		if o.Token == "" {
+			return fmt.Errorf("token is required for token auth")
+		}
+	case MethodBasic:
+		if o.Username == "" || o.Password == "" {
+			return fmt.Errorf("username and password are required for basic auth")
+		}
+	case MethodOAuth:
+		if o.Token == "" && (o.ClientID == "" || o.ClientSecret == "") {
+			return fmt.Errorf("token or client_id/client_secret required for OAuth")
+		}
+	}
+
+	return nil
+}
+
+// AddPlatformCredential adds a platform credential (K8s, OpenShift, Cloud).
+func (m *Manager) AddPlatformCredential(ctx context.Context, opts *PlatformCredentialOptions) (*Credential, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid platform credential options: %w", err)
+	}
+
+	cred := &Credential{
+		Name:      opts.Name,
+		Type:      CredentialTypePlatform,
+		Provider:  string(opts.Platform),
+		Method:    opts.Method,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Metadata: CredentialMetadata{
+			Description: opts.Description,
+			URL:         opts.URL,
+			Namespace:   opts.Namespace,
+			SecretName:  opts.SecretName,
+		},
+	}
+
+	// Set credential data based on method
+	switch opts.Method {
+	case MethodToken:
+		cred.Data.Token = opts.Token
+	case MethodServiceAccount:
+		cred.Data.Token = opts.Token
+		cred.Data.CACert = opts.CACert
+	case MethodOIDC:
+		cred.Data.ClientID = opts.ClientID
+		cred.Data.ClientSecret = opts.ClientSecret
+	case MethodAWSIRSA:
+		cred.Data.AWSRoleARN = opts.AWSRoleARN
+	case MethodAzureAAD:
+		cred.Data.AzureTenantID = opts.AzureTenantID
+		cred.Data.AzureClientID = opts.AzureClientID
+	case MethodBasic:
+		cred.Data.Username = opts.Username
+		cred.Data.Password = opts.Password
+	}
+
+	if err := m.store.Save(ctx, cred); err != nil {
+		return nil, fmt.Errorf("failed to save credential: %w", err)
+	}
+
+	return cred, nil
+}
+
+// PlatformCredentialOptions contains options for creating platform credentials.
+type PlatformCredentialOptions struct {
+	Name          string
+	Platform      PlatformType
+	Method        Method
+	URL           string
+	Description   string
+	Namespace     string
+	SecretName    string
+	Token         string
+	Username      string
+	Password      string
+	CACert        string
+	ClientID      string
+	ClientSecret  string
+	AWSRoleARN    string
+	AzureTenantID string
+	AzureClientID string
+}
+
+// Validate validates the platform credential options.
+func (o *PlatformCredentialOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if o.Platform == "" {
+		return fmt.Errorf("platform is required")
+	}
+	if o.Method == "" {
+		return fmt.Errorf("method is required")
+	}
+
+	switch o.Method {
+	case MethodToken, MethodServiceAccount:
+		if o.Token == "" {
+			return fmt.Errorf("token is required for token/service-account auth")
+		}
+	case MethodOIDC:
+		if o.ClientID == "" {
+			return fmt.Errorf("client_id is required for OIDC auth")
+		}
+	case MethodAWSIRSA:
+		if o.AWSRoleARN == "" {
+			return fmt.Errorf("aws_role_arn is required for AWS IRSA")
+		}
+	case MethodAzureAAD:
+		if o.AzureTenantID == "" || o.AzureClientID == "" {
+			return fmt.Errorf("azure_tenant_id and azure_client_id required for Azure AAD")
+		}
+	case MethodBasic:
+		if o.Username == "" || o.Password == "" {
+			return fmt.Errorf("username and password required for basic auth")
+		}
+	}
+
+	return nil
+}
+
+// AddRegistryCredential adds a container registry credential.
+func (m *Manager) AddRegistryCredential(ctx context.Context, opts *RegistryCredentialOptions) (*Credential, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid registry credential options: %w", err)
+	}
+
+	cred := &Credential{
+		Name:      opts.Name,
+		Type:      CredentialTypeRegistry,
+		Provider:  opts.Registry,
+		Method:    MethodBasic,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Data: CredentialData{
+			Username: opts.Username,
+			Password: opts.Password,
+		},
+		Metadata: CredentialMetadata{
+			Description: opts.Description,
+			URL:         opts.URL,
+			Namespace:   opts.Namespace,
+			SecretName:  opts.SecretName,
+		},
+	}
+
+	if err := m.store.Save(ctx, cred); err != nil {
+		return nil, fmt.Errorf("failed to save credential: %w", err)
+	}
+
+	return cred, nil
+}
+
+// RegistryCredentialOptions contains options for creating registry credentials.
+type RegistryCredentialOptions struct {
+	Name        string
+	Registry    string
+	URL         string
+	Username    string
+	Password    string
+	Description string
+	Namespace   string
+	SecretName  string
+}
+
+// Validate validates the registry credential options.
+func (o *RegistryCredentialOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if o.URL == "" {
+		return fmt.Errorf("url is required")
+	}
+	if o.Username == "" || o.Password == "" {
+		return fmt.Errorf("username and password are required")
+	}
+	return nil
+}
+
+// GetCredential retrieves a credential by name.
+func (m *Manager) GetCredential(ctx context.Context, name string) (*Credential, error) {
+	return m.store.Get(ctx, name)
+}
+
+// ListCredentials lists all credentials of a given type.
+func (m *Manager) ListCredentials(ctx context.Context, credType CredentialType) ([]*Credential, error) {
+	return m.store.List(ctx, credType)
+}
+
+// DeleteCredential deletes a credential by name.
+func (m *Manager) DeleteCredential(ctx context.Context, name string) error {
+	return m.store.Delete(ctx, name)
+}
+
+// TestCredential tests if a credential is valid.
+func (m *Manager) TestCredential(ctx context.Context, name string) (*TestResult, error) {
+	cred, err := m.store.Get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("credential not found: %w", err)
+	}
+
+	result := &TestResult{
+		Name:     name,
+		Type:     cred.Type,
+		Provider: cred.Provider,
+		TestedAt: time.Now(),
+	}
+
+	switch cred.Type {
+	case CredentialTypeGit:
+		result.Success, result.Message = m.testGitCredential(ctx, cred)
+	case CredentialTypePlatform:
+		result.Success, result.Message = m.testPlatformCredential(ctx, cred)
+	case CredentialTypeRegistry:
+		result.Success, result.Message = m.testRegistryCredential(ctx, cred)
+	default:
+		result.Success = false
+		result.Message = fmt.Sprintf("unsupported credential type: %s", cred.Type)
+	}
+
+	return result, nil
+}
+
+// TestResult contains the result of testing a credential.
+type TestResult struct {
+	Name     string         `json:"name"`
+	Type     CredentialType `json:"type"`
+	Provider string         `json:"provider"`
+	Success  bool           `json:"success"`
+	Message  string         `json:"message"`
+	TestedAt time.Time      `json:"tested_at"`
+}
+
+func (m *Manager) testGitCredential(_ context.Context, cred *Credential) (success bool, message string) {
+	// Basic validation - actual testing would involve Git operations
+	switch cred.Method {
+	case MethodSSH:
+		if cred.Data.SSHPrivateKey == "" {
+			return false, "SSH private key is empty"
+		}
+		return true, "SSH key is present (connection test requires Git operation)"
+	case MethodToken:
+		if cred.Data.Token == "" {
+			return false, "Token is empty"
+		}
+		if len(cred.Data.Token) < 10 {
+			return false, "Token appears to be too short"
+		}
+		return true, "Token is present and valid format"
+	case MethodBasic:
+		if cred.Data.Username == "" || cred.Data.Password == "" {
+			return false, "Username or password is empty"
+		}
+		return true, "Basic auth credentials are present"
+	default:
+		return false, fmt.Sprintf("unsupported auth method: %s", cred.Method)
+	}
+}
+
+func (m *Manager) testPlatformCredential(_ context.Context, cred *Credential) (success bool, message string) {
+	switch cred.Method {
+	case MethodToken, MethodServiceAccount:
+		if cred.Data.Token == "" {
+			return false, "Token is empty"
+		}
+		return true, "Token is present"
+	case MethodOIDC:
+		if cred.Data.ClientID == "" {
+			return false, "Client ID is empty"
+		}
+		return true, "OIDC credentials are present"
+	case MethodAWSIRSA:
+		if cred.Data.AWSRoleARN == "" {
+			return false, "AWS Role ARN is empty"
+		}
+		return true, "AWS IRSA configuration is present"
+	case MethodAzureAAD:
+		if cred.Data.AzureTenantID == "" || cred.Data.AzureClientID == "" {
+			return false, "Azure tenant ID or client ID is empty"
+		}
+		return true, "Azure AAD configuration is present"
+	default:
+		return false, fmt.Sprintf("unsupported auth method: %s", cred.Method)
+	}
+}
+
+func (m *Manager) testRegistryCredential(_ context.Context, cred *Credential) (success bool, message string) {
+	if cred.Data.Username == "" || cred.Data.Password == "" {
+		return false, "Username or password is empty"
+	}
+	return true, "Registry credentials are present"
+}
+
+// GenerateKubernetesSecret generates a Kubernetes Secret manifest for a credential.
+func (m *Manager) GenerateKubernetesSecret(ctx context.Context, name string) (string, error) {
+	cred, err := m.store.Get(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("credential not found: %w", err)
+	}
+
+	namespace := cred.Metadata.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	secretName := cred.Metadata.SecretName
+	if secretName == "" {
+		secretName = cred.Name
+	}
+
+	labels := cred.Metadata.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["app.kubernetes.io/managed-by"] = "gitopsi"
+
+	switch cred.Type {
+	case CredentialTypeGit:
+		return m.generateGitSecret(cred, namespace, secretName, labels)
+	case CredentialTypePlatform:
+		return m.generatePlatformSecret(cred, namespace, secretName, labels)
+	case CredentialTypeRegistry:
+		return m.generateRegistrySecret(cred, namespace, secretName, labels)
+	default:
+		return "", fmt.Errorf("unsupported credential type: %s", cred.Type)
+	}
+}
+
+func (m *Manager) generateGitSecret(cred *Credential, namespace, secretName string, labels map[string]string) (string, error) {
+	secret := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      secretName,
+			"namespace": namespace,
+			"labels":    labels,
+		},
+		"type": "Opaque",
+	}
+
+	stringData := make(map[string]string)
+
+	switch cred.Method {
+	case MethodSSH:
+		secret["type"] = "kubernetes.io/ssh-auth"
+		stringData["ssh-privatekey"] = cred.Data.SSHPrivateKey
+		if cred.Data.SSHKnownHosts != "" {
+			stringData["known_hosts"] = cred.Data.SSHKnownHosts
+		}
+	case MethodToken:
+		stringData["username"] = cred.Data.Username
+		stringData["password"] = cred.Data.Token
+	case MethodBasic:
+		secret["type"] = "kubernetes.io/basic-auth"
+		stringData["username"] = cred.Data.Username
+		stringData["password"] = cred.Data.Password
+	}
+
+	secret["stringData"] = stringData
+
+	return toYAML(secret)
+}
+
+func (m *Manager) generatePlatformSecret(cred *Credential, namespace, secretName string, labels map[string]string) (string, error) {
+	secret := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      secretName,
+			"namespace": namespace,
+			"labels":    labels,
+		},
+		"type": "Opaque",
+	}
+
+	stringData := make(map[string]string)
+
+	switch cred.Method {
+	case MethodToken, MethodServiceAccount:
+		stringData["token"] = cred.Data.Token
+		if cred.Data.CACert != "" {
+			stringData["ca.crt"] = cred.Data.CACert
+		}
+	case MethodOIDC:
+		stringData["client-id"] = cred.Data.ClientID
+		if cred.Data.ClientSecret != "" {
+			stringData["client-secret"] = cred.Data.ClientSecret
+		}
+	case MethodBasic:
+		stringData["username"] = cred.Data.Username
+		stringData["password"] = cred.Data.Password
+	}
+
+	secret["stringData"] = stringData
+
+	return toYAML(secret)
+}
+
+func (m *Manager) generateRegistrySecret(cred *Credential, namespace, secretName string, labels map[string]string) (string, error) {
+	// Generate docker-registry type secret
+	registryURL := cred.Metadata.URL
+	if registryURL == "" {
+		registryURL = "https://index.docker.io/v1/"
+	}
+
+	authStr := base64.StdEncoding.EncodeToString([]byte(cred.Data.Username + ":" + cred.Data.Password))
+	dockerConfig := map[string]interface{}{
+		"auths": map[string]interface{}{
+			registryURL: map[string]string{
+				"username": cred.Data.Username,
+				"password": cred.Data.Password,
+				"auth":     authStr,
+			},
+		},
+	}
+	dockerConfigBytes, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal docker config: %w", err)
+	}
+	dockerConfigJSON := string(dockerConfigBytes)
+
+	secret := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      secretName,
+			"namespace": namespace,
+			"labels":    labels,
+		},
+		"type": "kubernetes.io/dockerconfigjson",
+		"stringData": map[string]string{
+			".dockerconfigjson": dockerConfigJSON,
+		},
+	}
+
+	return toYAML(secret)
+}
+
+// GenerateArgoCDRepoSecret generates an ArgoCD repository secret.
+func (m *Manager) GenerateArgoCDRepoSecret(ctx context.Context, name, argoCDNamespace string) (string, error) {
+	cred, err := m.store.Get(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("credential not found: %w", err)
+	}
+
+	if cred.Type != CredentialTypeGit {
+		return "", fmt.Errorf("credential must be of type 'git'")
+	}
+
+	secretName := cred.Metadata.SecretName
+	if secretName == "" {
+		secretName = fmt.Sprintf("repo-%s", cred.Name)
+	}
+
+	labels := map[string]string{
+		"argocd.argoproj.io/secret-type": "repository",
+		"app.kubernetes.io/managed-by":   "gitopsi",
+	}
+
+	secret := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      secretName,
+			"namespace": argoCDNamespace,
+			"labels":    labels,
+		},
+		"type": "Opaque",
+	}
+
+	stringData := map[string]string{
+		"type": "git",
+		"url":  cred.Metadata.URL,
+	}
+
+	switch cred.Method {
+	case MethodSSH:
+		stringData["sshPrivateKey"] = cred.Data.SSHPrivateKey
+	case MethodToken:
+		stringData["username"] = cred.Data.Username
+		if stringData["username"] == "" {
+			stringData["username"] = "git"
+		}
+		stringData["password"] = cred.Data.Token
+	case MethodBasic:
+		stringData["username"] = cred.Data.Username
+		stringData["password"] = cred.Data.Password
+	}
+
+	secret["stringData"] = stringData
+
+	return toYAML(secret)
+}
+
+// GenerateFluxGitRepositorySecret generates a Flux GitRepository secret.
+func (m *Manager) GenerateFluxGitRepositorySecret(ctx context.Context, name, namespace string) (string, error) {
+	cred, err := m.store.Get(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("credential not found: %w", err)
+	}
+
+	if cred.Type != CredentialTypeGit {
+		return "", fmt.Errorf("credential must be of type 'git'")
+	}
+
+	secretName := cred.Metadata.SecretName
+	if secretName == "" {
+		secretName = fmt.Sprintf("flux-git-%s", cred.Name)
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/managed-by": "gitopsi",
+	}
+
+	secret := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      secretName,
+			"namespace": namespace,
+			"labels":    labels,
+		},
+		"type": "Opaque",
+	}
+
+	stringData := make(map[string]string)
+
+	switch cred.Method {
+	case MethodSSH:
+		stringData["identity"] = cred.Data.SSHPrivateKey
+		stringData["identity.pub"] = cred.Data.SSHPublicKey
+		if cred.Data.SSHKnownHosts != "" {
+			stringData["known_hosts"] = cred.Data.SSHKnownHosts
+		}
+	case MethodToken:
+		stringData["username"] = cred.Data.Username
+		if stringData["username"] == "" {
+			stringData["username"] = "git"
+		}
+		stringData["password"] = cred.Data.Token
+	case MethodBasic:
+		stringData["username"] = cred.Data.Username
+		stringData["password"] = cred.Data.Password
+	}
+
+	secret["stringData"] = stringData
+
+	return toYAML(secret)
+}
+
+// LoadSSHKeyFromFile loads an SSH private key from a file.
+func LoadSSHKeyFromFile(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SSH key: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// LoadSSHKnownHosts loads known_hosts from a file.
+func LoadSSHKnownHosts(path string) (string, error) {
+	if path == "" {
+		// Try default location
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", nil
+		}
+		path = filepath.Join(home, ".ssh", "known_hosts")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil // Known hosts is optional
+	}
+
+	return string(data), nil
+}
+
+// GetTokenFromEnv retrieves a token from environment variable.
+func GetTokenFromEnv(envVar string) string {
+	return os.Getenv(envVar)
+}
+
+func toYAML(v interface{}) (string, error) {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// MaskCredential returns a masked version of the credential for display.
+func MaskCredential(value string) string {
+	if len(value) <= 8 {
+		return strings.Repeat("*", len(value))
+	}
+	return value[:4] + strings.Repeat("*", len(value)-8) + value[len(value)-4:]
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,875 @@
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCredentialTypes(t *testing.T) {
+	tests := []struct {
+		credType CredentialType
+		expected string
+	}{
+		{CredentialTypeGit, "git"},
+		{CredentialTypePlatform, "platform"},
+		{CredentialTypeRegistry, "registry"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.credType) != tt.expected {
+			t.Errorf("CredentialType mismatch: got %s, want %s", tt.credType, tt.expected)
+		}
+	}
+}
+
+func TestMethods(t *testing.T) {
+	tests := []struct {
+		method   Method
+		expected string
+	}{
+		{MethodSSH, "ssh"},
+		{MethodToken, "token"},
+		{MethodBasic, "basic"},
+		{MethodOAuth, "oauth"},
+		{MethodServiceAccount, "service-account"},
+		{MethodOIDC, "oidc"},
+		{MethodAWSIRSA, "aws-irsa"},
+		{MethodAzureAAD, "azure-aad"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.method) != tt.expected {
+			t.Errorf("Method mismatch: got %s, want %s", tt.method, tt.expected)
+		}
+	}
+}
+
+func TestGitProviders(t *testing.T) {
+	tests := []struct {
+		provider GitProvider
+		expected string
+	}{
+		{GitProviderGitHub, "github"},
+		{GitProviderGitLab, "gitlab"},
+		{GitProviderBitbucket, "bitbucket"},
+		{GitProviderAzureDevOps, "azure-devops"},
+		{GitProviderGitea, "gitea"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.provider) != tt.expected {
+			t.Errorf("GitProvider mismatch: got %s, want %s", tt.provider, tt.expected)
+		}
+	}
+}
+
+func TestPlatformTypes(t *testing.T) {
+	tests := []struct {
+		platform PlatformType
+		expected string
+	}{
+		{PlatformKubernetes, "kubernetes"},
+		{PlatformOpenShift, "openshift"},
+		{PlatformAWS, "aws"},
+		{PlatformAzure, "azure"},
+		{PlatformGCP, "gcp"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.platform) != tt.expected {
+			t.Errorf("PlatformType mismatch: got %s, want %s", tt.platform, tt.expected)
+		}
+	}
+}
+
+func TestSecretFormats(t *testing.T) {
+	tests := []struct {
+		format   SecretFormat
+		expected string
+	}{
+		{SecretFormatPlain, "plain"},
+		{SecretFormatSealed, "sealed"},
+		{SecretFormatSops, "sops"},
+		{SecretFormatExternalSecret, "external-secret"},
+		{SecretFormatVault, "vault"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.format) != tt.expected {
+			t.Errorf("SecretFormat mismatch: got %s, want %s", tt.format, tt.expected)
+		}
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+
+	if manager == nil {
+		t.Fatal("NewManager returned nil")
+	}
+	if manager.store == nil {
+		t.Fatal("Manager store is nil")
+	}
+	if manager.secretFormat != SecretFormatPlain {
+		t.Errorf("Manager secretFormat: got %s, want %s", manager.secretFormat, SecretFormatPlain)
+	}
+}
+
+func TestGitCredentialOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    GitCredentialOptions
+		wantErr bool
+	}{
+		{
+			name: "valid token auth",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderGitHub,
+				Method:   MethodToken,
+				Token:    "ghp_xxxxxxxxxxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ssh auth",
+			opts: GitCredentialOptions{
+				Name:          "test",
+				Provider:      GitProviderGitLab,
+				Method:        MethodSSH,
+				SSHPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\n...",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid basic auth",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderBitbucket,
+				Method:   MethodBasic,
+				Username: "user",
+				Password: "pass",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			opts: GitCredentialOptions{
+				Provider: GitProviderGitHub,
+				Method:   MethodToken,
+				Token:    "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing provider",
+			opts: GitCredentialOptions{
+				Name:   "test",
+				Method: MethodToken,
+				Token:  "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing method",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderGitHub,
+				Token:    "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "token auth without token",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderGitHub,
+				Method:   MethodToken,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ssh auth without key",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderGitHub,
+				Method:   MethodSSH,
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic auth without password",
+			opts: GitCredentialOptions{
+				Name:     "test",
+				Provider: GitProviderGitHub,
+				Method:   MethodBasic,
+				Username: "user",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPlatformCredentialOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    PlatformCredentialOptions
+		wantErr bool
+	}{
+		{
+			name: "valid token auth",
+			opts: PlatformCredentialOptions{
+				Name:     "test",
+				Platform: PlatformOpenShift,
+				Method:   MethodToken,
+				Token:    "sha256~xxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid aws irsa",
+			opts: PlatformCredentialOptions{
+				Name:       "test",
+				Platform:   PlatformAWS,
+				Method:     MethodAWSIRSA,
+				AWSRoleARN: "arn:aws:iam::123456789:role/test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid azure aad",
+			opts: PlatformCredentialOptions{
+				Name:          "test",
+				Platform:      PlatformAzure,
+				Method:        MethodAzureAAD,
+				AzureTenantID: "tenant-123",
+				AzureClientID: "client-456",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			opts: PlatformCredentialOptions{
+				Platform: PlatformOpenShift,
+				Method:   MethodToken,
+				Token:    "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "token auth without token",
+			opts: PlatformCredentialOptions{
+				Name:     "test",
+				Platform: PlatformKubernetes,
+				Method:   MethodToken,
+			},
+			wantErr: true,
+		},
+		{
+			name: "aws irsa without role arn",
+			opts: PlatformCredentialOptions{
+				Name:     "test",
+				Platform: PlatformAWS,
+				Method:   MethodAWSIRSA,
+			},
+			wantErr: true,
+		},
+		{
+			name: "azure aad without tenant",
+			opts: PlatformCredentialOptions{
+				Name:          "test",
+				Platform:      PlatformAzure,
+				Method:        MethodAzureAAD,
+				AzureClientID: "client-123",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegistryCredentialOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    RegistryCredentialOptions
+		wantErr bool
+	}{
+		{
+			name: "valid registry cred",
+			opts: RegistryCredentialOptions{
+				Name:     "test",
+				URL:      "docker.io",
+				Username: "user",
+				Password: "pass",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			opts: RegistryCredentialOptions{
+				URL:      "docker.io",
+				Username: "user",
+				Password: "pass",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing url",
+			opts: RegistryCredentialOptions{
+				Name:     "test",
+				Username: "user",
+				Password: "pass",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing credentials",
+			opts: RegistryCredentialOptions{
+				Name: "test",
+				URL:  "docker.io",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestManager_AddGitCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	opts := &GitCredentialOptions{
+		Name:     "github-test",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "ghp_xxxxxxxxxxxx",
+		URL:      "https://github.com/test/repo",
+	}
+
+	cred, err := manager.AddGitCredential(ctx, opts)
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	if cred.Name != opts.Name {
+		t.Errorf("Name: got %s, want %s", cred.Name, opts.Name)
+	}
+	if cred.Type != CredentialTypeGit {
+		t.Errorf("Type: got %s, want %s", cred.Type, CredentialTypeGit)
+	}
+	if cred.Provider != string(opts.Provider) {
+		t.Errorf("Provider: got %s, want %s", cred.Provider, opts.Provider)
+	}
+	if cred.Data.Token != opts.Token {
+		t.Errorf("Token: got %s, want %s", cred.Data.Token, opts.Token)
+	}
+}
+
+func TestManager_AddPlatformCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	opts := &PlatformCredentialOptions{
+		Name:     "openshift-test",
+		Platform: PlatformOpenShift,
+		Method:   MethodToken,
+		Token:    "sha256~xxxxxxxxxxxx",
+		URL:      "https://api.cluster.example.com:6443",
+	}
+
+	cred, err := manager.AddPlatformCredential(ctx, opts)
+	if err != nil {
+		t.Fatalf("AddPlatformCredential failed: %v", err)
+	}
+
+	if cred.Name != opts.Name {
+		t.Errorf("Name: got %s, want %s", cred.Name, opts.Name)
+	}
+	if cred.Type != CredentialTypePlatform {
+		t.Errorf("Type: got %s, want %s", cred.Type, CredentialTypePlatform)
+	}
+	if cred.Data.Token != opts.Token {
+		t.Errorf("Token: got %s, want %s", cred.Data.Token, opts.Token)
+	}
+}
+
+func TestManager_AddRegistryCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	opts := &RegistryCredentialOptions{
+		Name:     "registry-test",
+		URL:      "docker.io",
+		Username: "testuser",
+		Password: "testpass",
+	}
+
+	cred, err := manager.AddRegistryCredential(ctx, opts)
+	if err != nil {
+		t.Fatalf("AddRegistryCredential failed: %v", err)
+	}
+
+	if cred.Name != opts.Name {
+		t.Errorf("Name: got %s, want %s", cred.Name, opts.Name)
+	}
+	if cred.Type != CredentialTypeRegistry {
+		t.Errorf("Type: got %s, want %s", cred.Type, CredentialTypeRegistry)
+	}
+	if cred.Data.Username != opts.Username {
+		t.Errorf("Username: got %s, want %s", cred.Data.Username, opts.Username)
+	}
+}
+
+func TestManager_GetCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	opts := &GitCredentialOptions{
+		Name:     "test-cred",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "test-token",
+	}
+
+	_, err := manager.AddGitCredential(ctx, opts)
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	// Get existing credential
+	cred, err := manager.GetCredential(ctx, "test-cred")
+	if err != nil {
+		t.Fatalf("GetCredential failed: %v", err)
+	}
+	if cred.Name != "test-cred" {
+		t.Errorf("Name: got %s, want %s", cred.Name, "test-cred")
+	}
+
+	// Get non-existing credential
+	_, err = manager.GetCredential(ctx, "non-existing")
+	if err == nil {
+		t.Error("GetCredential should fail for non-existing credential")
+	}
+}
+
+func TestManager_ListCredentials(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	// Add git credential
+	_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+		Name:     "git-cred",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "test-token",
+	})
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	// Add platform credential
+	_, err = manager.AddPlatformCredential(ctx, &PlatformCredentialOptions{
+		Name:     "platform-cred",
+		Platform: PlatformOpenShift,
+		Method:   MethodToken,
+		Token:    "test-token",
+	})
+	if err != nil {
+		t.Fatalf("AddPlatformCredential failed: %v", err)
+	}
+
+	// List all
+	all, err := manager.ListCredentials(ctx, "")
+	if err != nil {
+		t.Fatalf("ListCredentials failed: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("ListCredentials: got %d, want 2", len(all))
+	}
+
+	// List git only
+	gitCreds, err := manager.ListCredentials(ctx, CredentialTypeGit)
+	if err != nil {
+		t.Fatalf("ListCredentials failed: %v", err)
+	}
+	if len(gitCreds) != 1 {
+		t.Errorf("ListCredentials git: got %d, want 1", len(gitCreds))
+	}
+}
+
+func TestManager_DeleteCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+		Name:     "to-delete",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "test-token",
+	})
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	// Delete existing
+	err = manager.DeleteCredential(ctx, "to-delete")
+	if err != nil {
+		t.Fatalf("DeleteCredential failed: %v", err)
+	}
+
+	// Verify deleted
+	_, err = manager.GetCredential(ctx, "to-delete")
+	if err == nil {
+		t.Error("Credential should not exist after deletion")
+	}
+
+	// Delete non-existing
+	err = manager.DeleteCredential(ctx, "non-existing")
+	if err == nil {
+		t.Error("DeleteCredential should fail for non-existing credential")
+	}
+}
+
+func TestManager_TestCredential(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	// Add valid token credential
+	_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+		Name:     "valid-token",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "ghp_xxxxxxxxxxxxxxxxxxxx",
+	})
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	result, err := manager.TestCredential(ctx, "valid-token")
+	if err != nil {
+		t.Fatalf("TestCredential failed: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("TestCredential should succeed for valid token")
+	}
+
+	// Test non-existing credential
+	_, err = manager.TestCredential(ctx, "non-existing")
+	if err == nil {
+		t.Error("TestCredential should fail for non-existing credential")
+	}
+}
+
+func TestManager_GenerateKubernetesSecret(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		credType   CredentialType
+		method     Method
+		setupCred  func() error
+		wantFields []string
+	}{
+		{
+			name:     "git token secret",
+			credType: CredentialTypeGit,
+			method:   MethodToken,
+			setupCred: func() error {
+				_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+					Name:       "git-secret",
+					Provider:   GitProviderGitHub,
+					Method:     MethodToken,
+					Token:      "test-token",
+					Username:   "testuser",
+					Namespace:  "default",
+					SecretName: "my-git-secret",
+				})
+				return err
+			},
+			wantFields: []string{"kind: Secret", "name: my-git-secret", "namespace: default"},
+		},
+		{
+			name:     "git ssh secret",
+			credType: CredentialTypeGit,
+			method:   MethodSSH,
+			setupCred: func() error {
+				_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+					Name:          "git-ssh",
+					Provider:      GitProviderGitLab,
+					Method:        MethodSSH,
+					SSHPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+					Namespace:     "gitlab",
+				})
+				return err
+			},
+			wantFields: []string{"kind: Secret", "ssh-privatekey"},
+		},
+		{
+			name:     "registry secret",
+			credType: CredentialTypeRegistry,
+			setupCred: func() error {
+				_, err := manager.AddRegistryCredential(ctx, &RegistryCredentialOptions{
+					Name:      "registry-secret",
+					URL:       "docker.io",
+					Username:  "user",
+					Password:  "pass",
+					Namespace: "registry-ns",
+				})
+				return err
+			},
+			wantFields: []string{"kind: Secret", "kubernetes.io/dockerconfigjson", ".dockerconfigjson"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.setupCred(); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+
+			// Get credential name from test
+			var credName string
+			switch tt.name {
+			case "git token secret":
+				credName = "git-secret"
+			case "git ssh secret":
+				credName = "git-ssh"
+			case "registry secret":
+				credName = "registry-secret"
+			}
+
+			output, err := manager.GenerateKubernetesSecret(ctx, credName)
+			if err != nil {
+				t.Fatalf("GenerateKubernetesSecret failed: %v", err)
+			}
+
+			for _, field := range tt.wantFields {
+				if !strings.Contains(output, field) {
+					t.Errorf("Output missing expected field: %s", field)
+				}
+			}
+		})
+	}
+}
+
+func TestManager_GenerateArgoCDRepoSecret(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+		Name:     "argocd-repo",
+		Provider: GitProviderGitHub,
+		Method:   MethodToken,
+		Token:    "test-token",
+		Username: "git",
+		URL:      "https://github.com/test/repo",
+	})
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	output, err := manager.GenerateArgoCDRepoSecret(ctx, "argocd-repo", "argocd")
+	if err != nil {
+		t.Fatalf("GenerateArgoCDRepoSecret failed: %v", err)
+	}
+
+	wantFields := []string{
+		"kind: Secret",
+		"namespace: argocd",
+		"argocd.argoproj.io/secret-type: repository",
+		"type: git",
+		"url: https://github.com/test/repo",
+	}
+
+	for _, field := range wantFields {
+		if !strings.Contains(output, field) {
+			t.Errorf("Output missing expected field: %s", field)
+		}
+	}
+}
+
+func TestManager_GenerateFluxGitRepositorySecret(t *testing.T) {
+	store := NewMemoryStore()
+	manager := NewManager(store, SecretFormatPlain)
+	ctx := context.Background()
+
+	_, err := manager.AddGitCredential(ctx, &GitCredentialOptions{
+		Name:          "flux-repo",
+		Provider:      GitProviderGitLab,
+		Method:        MethodSSH,
+		SSHPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+		SSHPublicKey:  "ssh-rsa AAAA...",
+	})
+	if err != nil {
+		t.Fatalf("AddGitCredential failed: %v", err)
+	}
+
+	output, err := manager.GenerateFluxGitRepositorySecret(ctx, "flux-repo", "flux-system")
+	if err != nil {
+		t.Fatalf("GenerateFluxGitRepositorySecret failed: %v", err)
+	}
+
+	wantFields := []string{
+		"kind: Secret",
+		"namespace: flux-system",
+		"identity:",
+		"identity.pub:",
+	}
+
+	for _, field := range wantFields {
+		if !strings.Contains(output, field) {
+			t.Errorf("Output missing expected field: %s", field)
+		}
+	}
+}
+
+func TestLoadSSHKeyFromFile(t *testing.T) {
+	// Create temp file with SSH key
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test_key")
+	keyContent := "-----BEGIN RSA PRIVATE KEY-----\ntest content\n-----END RSA PRIVATE KEY-----"
+
+	if err := os.WriteFile(keyPath, []byte(keyContent), 0600); err != nil {
+		t.Fatalf("Failed to write temp key: %v", err)
+	}
+
+	// Test loading
+	loaded, err := LoadSSHKeyFromFile(keyPath)
+	if err != nil {
+		t.Fatalf("LoadSSHKeyFromFile failed: %v", err)
+	}
+	if loaded != keyContent {
+		t.Errorf("Content mismatch: got %q, want %q", loaded, keyContent)
+	}
+
+	// Test non-existing file
+	_, err = LoadSSHKeyFromFile("/non/existing/path")
+	if err == nil {
+		t.Error("LoadSSHKeyFromFile should fail for non-existing file")
+	}
+}
+
+func TestMaskCredential(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantLen  int
+		wantMask bool
+	}{
+		{"short", 5, false},            // <= 8 chars: all masked
+		{"ghp_xxxxxxxxxxxx", 16, true}, // > 8 chars: partial mask
+		{"a", 1, false},
+	}
+
+	for _, tt := range tests {
+		result := MaskCredential(tt.input)
+		if len(result) != tt.wantLen {
+			t.Errorf("MaskCredential(%q): got len %d, want %d", tt.input, len(result), tt.wantLen)
+		}
+		if tt.wantMask {
+			// Should have visible chars at start and end
+			if !strings.HasPrefix(result, tt.input[:4]) {
+				t.Errorf("MaskCredential should preserve first 4 chars")
+			}
+			if !strings.HasSuffix(result, tt.input[len(tt.input)-4:]) {
+				t.Errorf("MaskCredential should preserve last 4 chars")
+			}
+		}
+	}
+}
+
+func TestGetTokenFromEnv(t *testing.T) {
+	// Set test environment variable
+	os.Setenv("TEST_TOKEN_VAR", "test-value")
+	defer os.Unsetenv("TEST_TOKEN_VAR")
+
+	result := GetTokenFromEnv("TEST_TOKEN_VAR")
+	if result != "test-value" {
+		t.Errorf("GetTokenFromEnv: got %q, want %q", result, "test-value")
+	}
+
+	// Test non-existing
+	result = GetTokenFromEnv("NON_EXISTING_VAR")
+	if result != "" {
+		t.Errorf("GetTokenFromEnv should return empty for non-existing var")
+	}
+}
+
+func TestCredential_Fields(t *testing.T) {
+	now := time.Now()
+	expires := now.Add(24 * time.Hour)
+
+	cred := &Credential{
+		Name:     "test",
+		Type:     CredentialTypeGit,
+		Provider: "github",
+		Method:   MethodToken,
+		Data: CredentialData{
+			Token:    "test-token",
+			Username: "testuser",
+		},
+		Metadata: CredentialMetadata{
+			Description: "Test credential",
+			URL:         "https://github.com/test/repo",
+			Namespace:   "default",
+			SecretName:  "my-secret",
+			Labels:      map[string]string{"app": "test"},
+			Annotations: map[string]string{"note": "test"},
+			ExpiresAt:   &expires,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if cred.Name != "test" {
+		t.Errorf("Name: got %s, want test", cred.Name)
+	}
+	if cred.Data.Token != "test-token" {
+		t.Errorf("Token: got %s, want test-token", cred.Data.Token)
+	}
+	if cred.Metadata.Description != "Test credential" {
+		t.Errorf("Description: got %s, want Test credential", cred.Metadata.Description)
+	}
+	if cred.Metadata.ExpiresAt == nil {
+		t.Error("ExpiresAt should not be nil")
+	}
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,219 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileStore implements Store using file-based storage.
+type FileStore struct {
+	path        string
+	mu          sync.RWMutex
+	credentials map[string]*Credential
+}
+
+// NewFileStore creates a new file-based credential store.
+func NewFileStore(path string) (*FileStore, error) {
+	store := &FileStore{
+		path:        path,
+		credentials: make(map[string]*Credential),
+	}
+
+	// Load existing credentials if file exists
+	if _, err := os.Stat(path); err == nil {
+		if err := store.load(); err != nil {
+			return nil, fmt.Errorf("failed to load credentials: %w", err)
+		}
+	}
+
+	return store, nil
+}
+
+// Save stores a credential.
+func (s *FileStore) Save(ctx context.Context, cred *Credential) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.credentials[cred.Name] = cred
+	return s.persist()
+}
+
+// Get retrieves a credential by name.
+func (s *FileStore) Get(ctx context.Context, name string) (*Credential, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cred, ok := s.credentials[name]
+	if !ok {
+		return nil, fmt.Errorf("credential %q not found", name)
+	}
+	return cred, nil
+}
+
+// List returns all credentials of a given type.
+func (s *FileStore) List(ctx context.Context, credType CredentialType) ([]*Credential, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*Credential
+	for _, cred := range s.credentials {
+		if credType == "" || cred.Type == credType {
+			result = append(result, cred)
+		}
+	}
+	return result, nil
+}
+
+// Delete removes a credential.
+func (s *FileStore) Delete(ctx context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.credentials[name]; !ok {
+		return fmt.Errorf("credential %q not found", name)
+	}
+
+	delete(s.credentials, name)
+	return s.persist()
+}
+
+// Exists checks if a credential exists.
+func (s *FileStore) Exists(ctx context.Context, name string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.credentials[name]
+	return ok, nil
+}
+
+func (s *FileStore) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return err
+	}
+
+	var fileData struct {
+		Credentials []*Credential `yaml:"credentials"`
+	}
+
+	if err := yaml.Unmarshal(data, &fileData); err != nil {
+		return err
+	}
+
+	for _, cred := range fileData.Credentials {
+		s.credentials[cred.Name] = cred
+	}
+
+	return nil
+}
+
+func (s *FileStore) persist() error {
+	// Ensure directory exists
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	creds := make([]*Credential, 0, len(s.credentials))
+	for _, cred := range s.credentials {
+		creds = append(creds, cred)
+	}
+
+	fileData := struct {
+		Credentials []*Credential `yaml:"credentials"`
+	}{
+		Credentials: creds,
+	}
+
+	data, err := yaml.Marshal(fileData)
+	if err != nil {
+		return err
+	}
+
+	// Write with restricted permissions (owner only)
+	return os.WriteFile(s.path, data, 0600)
+}
+
+// MemoryStore implements Store using in-memory storage.
+type MemoryStore struct {
+	mu          sync.RWMutex
+	credentials map[string]*Credential
+}
+
+// NewMemoryStore creates a new in-memory credential store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		credentials: make(map[string]*Credential),
+	}
+}
+
+// Save stores a credential.
+func (s *MemoryStore) Save(ctx context.Context, cred *Credential) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.credentials[cred.Name] = cred
+	return nil
+}
+
+// Get retrieves a credential by name.
+func (s *MemoryStore) Get(ctx context.Context, name string) (*Credential, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cred, ok := s.credentials[name]
+	if !ok {
+		return nil, fmt.Errorf("credential %q not found", name)
+	}
+	return cred, nil
+}
+
+// List returns all credentials of a given type.
+func (s *MemoryStore) List(ctx context.Context, credType CredentialType) ([]*Credential, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*Credential
+	for _, cred := range s.credentials {
+		if credType == "" || cred.Type == credType {
+			result = append(result, cred)
+		}
+	}
+	return result, nil
+}
+
+// Delete removes a credential.
+func (s *MemoryStore) Delete(ctx context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.credentials[name]; !ok {
+		return fmt.Errorf("credential %q not found", name)
+	}
+
+	delete(s.credentials, name)
+	return nil
+}
+
+// Exists checks if a credential exists.
+func (s *MemoryStore) Exists(ctx context.Context, name string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.credentials[name]
+	return ok, nil
+}
+
+// GetDefaultStorePath returns the default path for storing credentials.
+func GetDefaultStorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".gitopsi/credentials.yaml"
+	}
+	return filepath.Join(home, ".gitopsi", "credentials.yaml")
+}

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -1,0 +1,368 @@
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMemoryStore_Save(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	cred := &Credential{
+		Name:      "test-cred",
+		Type:      CredentialTypeGit,
+		Provider:  "github",
+		Method:    MethodToken,
+		CreatedAt: time.Now(),
+	}
+
+	err := store.Save(ctx, cred)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify saved
+	exists, err := store.Exists(ctx, "test-cred")
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
+	if !exists {
+		t.Error("Credential should exist after save")
+	}
+}
+
+func TestMemoryStore_Get(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Save credential
+	cred := &Credential{
+		Name:     "test-cred",
+		Type:     CredentialTypeGit,
+		Provider: "github",
+		Method:   MethodToken,
+		Data: CredentialData{
+			Token: "test-token",
+		},
+	}
+	_ = store.Save(ctx, cred)
+
+	// Get existing
+	retrieved, err := store.Get(ctx, "test-cred")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if retrieved.Name != "test-cred" {
+		t.Errorf("Name: got %s, want test-cred", retrieved.Name)
+	}
+	if retrieved.Data.Token != "test-token" {
+		t.Errorf("Token: got %s, want test-token", retrieved.Data.Token)
+	}
+
+	// Get non-existing
+	_, err = store.Get(ctx, "non-existing")
+	if err == nil {
+		t.Error("Get should fail for non-existing credential")
+	}
+}
+
+func TestMemoryStore_List(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Add multiple credentials
+	_ = store.Save(ctx, &Credential{
+		Name:     "git-1",
+		Type:     CredentialTypeGit,
+		Provider: "github",
+	})
+	_ = store.Save(ctx, &Credential{
+		Name:     "git-2",
+		Type:     CredentialTypeGit,
+		Provider: "gitlab",
+	})
+	_ = store.Save(ctx, &Credential{
+		Name:     "platform-1",
+		Type:     CredentialTypePlatform,
+		Provider: "openshift",
+	})
+
+	// List all
+	all, err := store.List(ctx, "")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("List all: got %d, want 3", len(all))
+	}
+
+	// List by type
+	gitCreds, err := store.List(ctx, CredentialTypeGit)
+	if err != nil {
+		t.Fatalf("List git failed: %v", err)
+	}
+	if len(gitCreds) != 2 {
+		t.Errorf("List git: got %d, want 2", len(gitCreds))
+	}
+
+	platformCreds, err := store.List(ctx, CredentialTypePlatform)
+	if err != nil {
+		t.Fatalf("List platform failed: %v", err)
+	}
+	if len(platformCreds) != 1 {
+		t.Errorf("List platform: got %d, want 1", len(platformCreds))
+	}
+}
+
+func TestMemoryStore_Delete(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Save and delete
+	_ = store.Save(ctx, &Credential{Name: "to-delete"})
+
+	err := store.Delete(ctx, "to-delete")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify deleted
+	exists, _ := store.Exists(ctx, "to-delete")
+	if exists {
+		t.Error("Credential should not exist after delete")
+	}
+
+	// Delete non-existing
+	err = store.Delete(ctx, "non-existing")
+	if err == nil {
+		t.Error("Delete should fail for non-existing credential")
+	}
+}
+
+func TestMemoryStore_Exists(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Check non-existing
+	exists, err := store.Exists(ctx, "test")
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
+	if exists {
+		t.Error("Should not exist initially")
+	}
+
+	// Save and check
+	_ = store.Save(ctx, &Credential{Name: "test"})
+	exists, err = store.Exists(ctx, "test")
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
+	if !exists {
+		t.Error("Should exist after save")
+	}
+}
+
+func TestFileStore_NewFileStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+
+	store, err := NewFileStore(storePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+	if store == nil {
+		t.Error("Store should not be nil")
+	}
+}
+
+func TestFileStore_SaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+	ctx := context.Background()
+
+	// Create store and save credentials
+	store1, err := NewFileStore(storePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	cred := &Credential{
+		Name:     "test-cred",
+		Type:     CredentialTypeGit,
+		Provider: "github",
+		Method:   MethodToken,
+		Data: CredentialData{
+			Token:    "secret-token",
+			Username: "testuser",
+		},
+		Metadata: CredentialMetadata{
+			URL:       "https://github.com/test/repo",
+			Namespace: "default",
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err = store1.Save(ctx, cred)
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Create new store instance to test loading
+	store2, err := NewFileStore(storePath)
+	if err != nil {
+		t.Fatalf("NewFileStore (reload) failed: %v", err)
+	}
+
+	loaded, err := store2.Get(ctx, "test-cred")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if loaded.Name != cred.Name {
+		t.Errorf("Name: got %s, want %s", loaded.Name, cred.Name)
+	}
+	if loaded.Data.Token != cred.Data.Token {
+		t.Errorf("Token: got %s, want %s", loaded.Data.Token, cred.Data.Token)
+	}
+	if loaded.Metadata.URL != cred.Metadata.URL {
+		t.Errorf("URL: got %s, want %s", loaded.Metadata.URL, cred.Metadata.URL)
+	}
+}
+
+func TestFileStore_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+	ctx := context.Background()
+
+	store, _ := NewFileStore(storePath)
+
+	// Save
+	_ = store.Save(ctx, &Credential{Name: "to-delete"})
+
+	// Delete
+	err := store.Delete(ctx, "to-delete")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify persistence
+	store2, _ := NewFileStore(storePath)
+	exists, _ := store2.Exists(ctx, "to-delete")
+	if exists {
+		t.Error("Deleted credential should not persist")
+	}
+}
+
+func TestFileStore_Permissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+	ctx := context.Background()
+
+	store, _ := NewFileStore(storePath)
+	_ = store.Save(ctx, &Credential{Name: "test"})
+
+	// Check file permissions (should be 0600)
+	info, err := os.Stat(storePath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("File permissions: got %o, want 0600", perm)
+	}
+}
+
+func TestFileStore_List(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+	ctx := context.Background()
+
+	store, _ := NewFileStore(storePath)
+
+	// Add credentials
+	_ = store.Save(ctx, &Credential{Name: "git-1", Type: CredentialTypeGit})
+	_ = store.Save(ctx, &Credential{Name: "git-2", Type: CredentialTypeGit})
+	_ = store.Save(ctx, &Credential{Name: "platform-1", Type: CredentialTypePlatform})
+
+	// List all
+	all, _ := store.List(ctx, "")
+	if len(all) != 3 {
+		t.Errorf("List all: got %d, want 3", len(all))
+	}
+
+	// List by type
+	gitCreds, _ := store.List(ctx, CredentialTypeGit)
+	if len(gitCreds) != 2 {
+		t.Errorf("List git: got %d, want 2", len(gitCreds))
+	}
+}
+
+func TestGetDefaultStorePath(t *testing.T) {
+	path := GetDefaultStorePath()
+	if path == "" {
+		t.Error("GetDefaultStorePath should not return empty string")
+	}
+	if !filepath.IsAbs(path) && path != ".gitopsi/credentials.yaml" {
+		t.Errorf("GetDefaultStorePath should return absolute path or fallback, got: %s", path)
+	}
+}
+
+func TestFileStore_InvalidPath(t *testing.T) {
+	// Test with path in non-writable location (Unix only)
+	if os.Getuid() == 0 {
+		t.Skip("Skipping as root user")
+	}
+
+	ctx := context.Background()
+	store, err := NewFileStore("/root/test/credentials.yaml")
+	if err != nil {
+		// This is expected if the path is not accessible
+		return
+	}
+
+	// If we got here, try to save - should fail
+	err = store.Save(ctx, &Credential{Name: "test"})
+	if err == nil {
+		t.Error("Save to non-writable path should fail")
+	}
+}
+
+func TestFileStore_ConcurrentAccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "credentials.yaml")
+	ctx := context.Background()
+
+	store, _ := NewFileStore(storePath)
+
+	// Concurrent saves
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(idx int) {
+			cred := &Credential{
+				Name:     "cred-" + string(rune('a'+idx)),
+				Type:     CredentialTypeGit,
+				Provider: "github",
+			}
+			_ = store.Save(ctx, cred)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify all saved
+	all, _ := store.List(ctx, "")
+	if len(all) != 10 {
+		t.Errorf("Concurrent save: got %d credentials, want 10", len(all))
+	}
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,509 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ihsanmokhlisse/gitopsi/internal/auth"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	authProvider   string
+	authMethod     string
+	authToken      string
+	authUsername   string
+	authPassword   string
+	authSSHKeyFile string
+	authURL        string
+	authNamespace  string
+	authSecretName string
+	authPlatform   string
+	authRegistry   string
+	authFormat     string
+	authRoleARN    string
+	authTenantID   string
+	authClientID   string
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage authentication credentials",
+	Long: `Manage authentication credentials for Git providers, platforms, and registries.
+
+Examples:
+  # Add GitHub token
+  gitopsi auth add git --provider github --method token --token $GITHUB_TOKEN
+
+  # Add SSH key for GitLab
+  gitopsi auth add git --provider gitlab --method ssh --ssh-key ~/.ssh/id_rsa
+
+  # Add OpenShift credentials
+  gitopsi auth add platform --platform openshift --method token --token $OCP_TOKEN
+
+  # Add registry credentials
+  gitopsi auth add registry --url registry.example.com --username user --password pass
+
+  # List all credentials
+  gitopsi auth list
+
+  # Test credentials
+  gitopsi auth test my-github-cred`,
+}
+
+var authAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add credentials",
+	Long:  "Add Git, platform, or registry credentials.",
+}
+
+var authAddGitCmd = &cobra.Command{
+	Use:   "git [name]",
+	Short: "Add Git provider credentials",
+	Long: `Add credentials for Git providers (GitHub, GitLab, Bitbucket, etc.)
+
+Examples:
+  gitopsi auth add git github-main --provider github --method token --token $GITHUB_TOKEN
+  gitopsi auth add git gitlab-ssh --provider gitlab --method ssh --ssh-key ~/.ssh/id_rsa`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthAddGit,
+}
+
+var authAddPlatformCmd = &cobra.Command{
+	Use:   "platform [name]",
+	Short: "Add platform credentials",
+	Long: `Add credentials for platforms (Kubernetes, OpenShift, AWS, Azure, GCP)
+
+Examples:
+  gitopsi auth add platform openshift-prod --platform openshift --method token --token $OCP_TOKEN
+  gitopsi auth add platform aws-prod --platform aws --method aws-irsa --role-arn arn:aws:iam::xxx`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthAddPlatform,
+}
+
+var authAddRegistryCmd = &cobra.Command{
+	Use:   "registry [name]",
+	Short: "Add container registry credentials",
+	Long: `Add credentials for container registries
+
+Examples:
+  gitopsi auth add registry docker-hub --url docker.io --username user --password pass
+  gitopsi auth add registry quay --url quay.io --username user --password pass`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthAddRegistry,
+}
+
+var authListCmd = &cobra.Command{
+	Use:   "list [type]",
+	Short: "List credentials",
+	Long: `List all credentials or filter by type (git, platform, registry)
+
+Examples:
+  gitopsi auth list
+  gitopsi auth list git
+  gitopsi auth list platform`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runAuthList,
+}
+
+var authTestCmd = &cobra.Command{
+	Use:   "test [name]",
+	Short: "Test credential validity",
+	Long: `Test if a credential is valid
+
+Examples:
+  gitopsi auth test github-main
+  gitopsi auth test openshift-prod`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthTest,
+}
+
+var authDeleteCmd = &cobra.Command{
+	Use:   "delete [name]",
+	Short: "Delete a credential",
+	Long: `Delete a stored credential
+
+Examples:
+  gitopsi auth delete github-main`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthDelete,
+}
+
+var authGenerateCmd = &cobra.Command{
+	Use:   "generate [name]",
+	Short: "Generate Kubernetes secret from credential",
+	Long: `Generate a Kubernetes Secret manifest from a stored credential
+
+Examples:
+  gitopsi auth generate github-main
+  gitopsi auth generate github-main --format argocd
+  gitopsi auth generate github-main --format flux`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAuthGenerate,
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+
+	// Add subcommands
+	authCmd.AddCommand(authAddCmd)
+	authCmd.AddCommand(authListCmd)
+	authCmd.AddCommand(authTestCmd)
+	authCmd.AddCommand(authDeleteCmd)
+	authCmd.AddCommand(authGenerateCmd)
+
+	// Add type-specific add commands
+	authAddCmd.AddCommand(authAddGitCmd)
+	authAddCmd.AddCommand(authAddPlatformCmd)
+	authAddCmd.AddCommand(authAddRegistryCmd)
+
+	// Git credentials flags
+	authAddGitCmd.Flags().StringVar(&authProvider, "provider", "", "Git provider: github, gitlab, bitbucket, azure-devops, gitea")
+	authAddGitCmd.Flags().StringVar(&authMethod, "method", "", "Auth method: ssh, token, basic, oauth")
+	authAddGitCmd.Flags().StringVar(&authToken, "token", "", "Access token (or use env var)")
+	authAddGitCmd.Flags().StringVar(&authUsername, "username", "", "Username for basic auth")
+	authAddGitCmd.Flags().StringVar(&authPassword, "password", "", "Password for basic auth")
+	authAddGitCmd.Flags().StringVar(&authSSHKeyFile, "ssh-key", "", "Path to SSH private key file")
+	authAddGitCmd.Flags().StringVar(&authURL, "url", "", "Git repository URL")
+	authAddGitCmd.Flags().StringVar(&authNamespace, "namespace", "", "Kubernetes namespace for generated secret")
+	authAddGitCmd.Flags().StringVar(&authSecretName, "secret-name", "", "Name for generated Kubernetes secret")
+
+	// Platform credentials flags
+	authAddPlatformCmd.Flags().StringVar(&authPlatform, "platform", "", "Platform: kubernetes, openshift, aws, azure, gcp")
+	authAddPlatformCmd.Flags().StringVar(&authMethod, "method", "", "Auth method: token, service-account, oidc, aws-irsa, azure-aad")
+	authAddPlatformCmd.Flags().StringVar(&authToken, "token", "", "Access token")
+	authAddPlatformCmd.Flags().StringVar(&authURL, "url", "", "Platform API URL")
+	authAddPlatformCmd.Flags().StringVar(&authRoleARN, "role-arn", "", "AWS IAM Role ARN for IRSA")
+	authAddPlatformCmd.Flags().StringVar(&authTenantID, "tenant-id", "", "Azure tenant ID")
+	authAddPlatformCmd.Flags().StringVar(&authClientID, "client-id", "", "Client ID for OIDC/Azure")
+	authAddPlatformCmd.Flags().StringVar(&authNamespace, "namespace", "", "Kubernetes namespace")
+	authAddPlatformCmd.Flags().StringVar(&authSecretName, "secret-name", "", "Secret name")
+
+	// Registry credentials flags
+	authAddRegistryCmd.Flags().StringVar(&authURL, "url", "", "Registry URL")
+	authAddRegistryCmd.Flags().StringVar(&authUsername, "username", "", "Registry username")
+	authAddRegistryCmd.Flags().StringVar(&authPassword, "password", "", "Registry password")
+	authAddRegistryCmd.Flags().StringVar(&authNamespace, "namespace", "", "Kubernetes namespace")
+	authAddRegistryCmd.Flags().StringVar(&authSecretName, "secret-name", "", "Secret name")
+
+	// Generate flags
+	authGenerateCmd.Flags().StringVar(&authFormat, "format", "k8s", "Output format: k8s, argocd, flux")
+	authGenerateCmd.Flags().StringVar(&authNamespace, "namespace", "", "Override namespace for generated secret")
+
+	// Mark required flags
+	_ = authAddGitCmd.MarkFlagRequired("provider")
+	_ = authAddGitCmd.MarkFlagRequired("method")
+	_ = authAddPlatformCmd.MarkFlagRequired("platform")
+	_ = authAddPlatformCmd.MarkFlagRequired("method")
+	_ = authAddRegistryCmd.MarkFlagRequired("url")
+	_ = authAddRegistryCmd.MarkFlagRequired("username")
+	_ = authAddRegistryCmd.MarkFlagRequired("password")
+}
+
+func getAuthManager() (*auth.Manager, error) {
+	storePath := auth.GetDefaultStorePath()
+	store, err := auth.NewFileStore(storePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize credential store: %w", err)
+	}
+	return auth.NewManager(store, auth.SecretFormatPlain), nil
+}
+
+func runAuthAddGit(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	opts := &auth.GitCredentialOptions{
+		Name:       name,
+		Provider:   auth.GitProvider(authProvider),
+		Method:     auth.Method(authMethod),
+		URL:        authURL,
+		Namespace:  authNamespace,
+		SecretName: authSecretName,
+		Username:   authUsername,
+	}
+
+	// Get token from flag or environment
+	switch opts.Method {
+	case auth.MethodSSH:
+		if authSSHKeyFile == "" {
+			return fmt.Errorf("--ssh-key is required for SSH authentication")
+		}
+		key, err := auth.LoadSSHKeyFromFile(authSSHKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to load SSH key: %w", err)
+		}
+		opts.SSHPrivateKey = key
+		knownHosts, _ := auth.LoadSSHKnownHosts("")
+		opts.SSHKnownHosts = knownHosts
+	case auth.MethodToken:
+		opts.Token = getTokenValue(authToken, authProvider)
+		if opts.Token == "" {
+			return fmt.Errorf("--token is required or set %s_TOKEN environment variable", strings.ToUpper(authProvider))
+		}
+	case auth.MethodBasic:
+		if authUsername == "" || authPassword == "" {
+			return fmt.Errorf("--username and --password are required for basic authentication")
+		}
+		opts.Username = authUsername
+		opts.Password = authPassword
+	case auth.MethodOAuth:
+		opts.Token = getTokenValue(authToken, authProvider)
+		opts.ClientID = authClientID
+	}
+
+	cred, err := manager.AddGitCredential(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to add credential: %w", err)
+	}
+
+	pterm.Success.Printf("Git credential '%s' added successfully\n", cred.Name)
+	pterm.Info.Printf("Provider: %s, Method: %s\n", cred.Provider, cred.Method)
+
+	return nil
+}
+
+func runAuthAddPlatform(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	opts := &auth.PlatformCredentialOptions{
+		Name:       name,
+		Platform:   auth.PlatformType(authPlatform),
+		Method:     auth.Method(authMethod),
+		URL:        authURL,
+		Namespace:  authNamespace,
+		SecretName: authSecretName,
+	}
+
+	switch opts.Method {
+	case auth.MethodToken, auth.MethodServiceAccount:
+		opts.Token = getTokenValue(authToken, authPlatform)
+		if opts.Token == "" {
+			return fmt.Errorf("--token is required or set %s_TOKEN environment variable", strings.ToUpper(authPlatform))
+		}
+	case auth.MethodOIDC:
+		opts.ClientID = authClientID
+		if opts.ClientID == "" {
+			return fmt.Errorf("--client-id is required for OIDC authentication")
+		}
+	case auth.MethodAWSIRSA:
+		opts.AWSRoleARN = authRoleARN
+		if opts.AWSRoleARN == "" {
+			return fmt.Errorf("--role-arn is required for AWS IRSA")
+		}
+	case auth.MethodAzureAAD:
+		opts.AzureTenantID = authTenantID
+		opts.AzureClientID = authClientID
+		if opts.AzureTenantID == "" || opts.AzureClientID == "" {
+			return fmt.Errorf("--tenant-id and --client-id are required for Azure AAD")
+		}
+	}
+
+	cred, err := manager.AddPlatformCredential(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to add credential: %w", err)
+	}
+
+	pterm.Success.Printf("Platform credential '%s' added successfully\n", cred.Name)
+	pterm.Info.Printf("Platform: %s, Method: %s\n", cred.Provider, cred.Method)
+
+	return nil
+}
+
+func runAuthAddRegistry(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	opts := &auth.RegistryCredentialOptions{
+		Name:       name,
+		URL:        authURL,
+		Username:   authUsername,
+		Password:   authPassword,
+		Namespace:  authNamespace,
+		SecretName: authSecretName,
+	}
+
+	cred, err := manager.AddRegistryCredential(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to add credential: %w", err)
+	}
+
+	pterm.Success.Printf("Registry credential '%s' added successfully\n", cred.Name)
+	pterm.Info.Printf("URL: %s\n", cred.Metadata.URL)
+
+	return nil
+}
+
+func runAuthList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	var credType auth.CredentialType
+	if len(args) > 0 {
+		credType = auth.CredentialType(args[0])
+	}
+
+	creds, err := manager.ListCredentials(ctx, credType)
+	if err != nil {
+		return fmt.Errorf("failed to list credentials: %w", err)
+	}
+
+	if len(creds) == 0 {
+		pterm.Info.Println("No credentials found")
+		return nil
+	}
+
+	tableData := [][]string{
+		{"NAME", "TYPE", "PROVIDER", "METHOD", "URL"},
+	}
+
+	for _, cred := range creds {
+		url := cred.Metadata.URL
+		if len(url) > 40 {
+			url = url[:37] + "..."
+		}
+		tableData = append(tableData, []string{
+			cred.Name,
+			string(cred.Type),
+			cred.Provider,
+			string(cred.Method),
+			url,
+		})
+	}
+
+	_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+	return nil
+}
+
+func runAuthTest(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	pterm.Info.Printf("Testing credential '%s'...\n", name)
+
+	result, err := manager.TestCredential(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to test credential: %w", err)
+	}
+
+	if result.Success {
+		pterm.Success.Printf("Credential '%s' is valid\n", name)
+		pterm.Info.Println(result.Message)
+	} else {
+		pterm.Error.Printf("Credential '%s' validation failed\n", name)
+		pterm.Error.Println(result.Message)
+		return fmt.Errorf("credential test failed")
+	}
+
+	return nil
+}
+
+func runAuthDelete(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	if err := manager.DeleteCredential(ctx, name); err != nil {
+		return fmt.Errorf("failed to delete credential: %w", err)
+	}
+
+	pterm.Success.Printf("Credential '%s' deleted successfully\n", name)
+	return nil
+}
+
+func runAuthGenerate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	manager, err := getAuthManager()
+	if err != nil {
+		return err
+	}
+
+	var output string
+
+	switch authFormat {
+	case "k8s", "kubernetes":
+		output, err = manager.GenerateKubernetesSecret(ctx, name)
+	case "argocd":
+		ns := authNamespace
+		if ns == "" {
+			ns = "argocd"
+		}
+		output, err = manager.GenerateArgoCDRepoSecret(ctx, name, ns)
+	case "flux":
+		ns := authNamespace
+		if ns == "" {
+			ns = "flux-system"
+		}
+		output, err = manager.GenerateFluxGitRepositorySecret(ctx, name, ns)
+	default:
+		return fmt.Errorf("unsupported format: %s", authFormat)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to generate secret: %w", err)
+	}
+
+	fmt.Println(output)
+	return nil
+}
+
+func getTokenValue(tokenFlag, provider string) string {
+	if tokenFlag != "" {
+		// Check if it's an environment variable reference
+		if strings.HasPrefix(tokenFlag, "$") {
+			envVar := strings.TrimPrefix(tokenFlag, "$")
+			return os.Getenv(envVar)
+		}
+		return tokenFlag
+	}
+
+	// Try common environment variables
+	envVars := []string{
+		strings.ToUpper(provider) + "_TOKEN",
+		"GITOPSI_" + strings.ToUpper(provider) + "_TOKEN",
+		"GIT_TOKEN",
+		"GITOPSI_GIT_TOKEN",
+	}
+
+	for _, env := range envVars {
+		if val := os.Getenv(env); val != "" {
+			return val
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Summary
Implements comprehensive authentication management for Git providers and platforms as specified in Issue #14.

## Features

### Credential Types
- **Git Credentials**: GitHub, GitLab, Bitbucket, Azure DevOps, Gitea
- **Platform Credentials**: Kubernetes, OpenShift, AWS, Azure, GCP
- **Registry Credentials**: Docker registries

### Authentication Methods
- SSH Key authentication
- Personal Access Token (PAT)
- Basic Authentication (username/password)
- OAuth tokens
- Service Account tokens
- OIDC/OpenID Connect
- AWS IRSA (IAM Roles for Service Accounts)
- Azure AAD Pod Identity

### CLI Commands
```bash
# Add Git credentials
gitopsi auth add git github-main --provider github --method token --token $GITHUB_TOKEN
gitopsi auth add git gitlab-ssh --provider gitlab --method ssh --ssh-key ~/.ssh/id_rsa

# Add platform credentials
gitopsi auth add platform openshift-prod --platform openshift --method token --token $OCP_TOKEN
gitopsi auth add platform aws-prod --platform aws --method aws-irsa --role-arn arn:aws:iam::xxx

# Add registry credentials
gitopsi auth add registry docker-hub --url docker.io --username user --password pass

# List, test, delete credentials
gitopsi auth list [git|platform|registry]
gitopsi auth test <name>
gitopsi auth delete <name>

# Generate secrets
gitopsi auth generate <name> --format k8s|argocd|flux
```

### Generated Resources
- Kubernetes Secrets (various types)
- ArgoCD Repository Secrets
- Flux GitRepository Secrets
- Docker Config JSON Secrets

### Storage
- File-based credential store (~/.gitopsi/credentials.yaml)
- Secure file permissions (0600)
- In-memory store for testing

## Testing
- Comprehensive unit tests for all credential types
- Tests for validation logic
- Tests for secret generation
- Tests for file store persistence
- Tests for concurrent access

## Closes #14